### PR TITLE
Better defaults and user modification of defaults through CR

### DIFF
--- a/docs/couchbase.md
+++ b/docs/couchbase.md
@@ -36,32 +36,42 @@ spec:
       use_persistent_storage: True
       class_name: "rook-ceph-block"
       volume_size: 10Gi
-    on_openshift: True
-    rh_pull_secret: <your registry.redhat.io pull secret>
 ```
 
 If you set `spec.couchbase.stroage.use_persistent_storage` to `true`, then you will need to provide a valid
 StorageClass name for `spec.couchbase.storage.class_name` and a valid volume size for `spec.couchbase.storage.volume_size`.
+
 Setting up a StorageClass is outside the scope of this documentation.
 
-Note that the upstream couchbase container images will not run on OpenShift as of this build,
-therefore logic is included in the role to pull from [registry.redhat.io](https://registry.redhat.io)
-in the case that `spec.couchbase.on_openshift` is set to `true` in the CR.
+> Note that the upstream couchbase container images will not run on OpenShift as of this build,
+> therefore the [default](../roles/couchbase-infra/defaults/main.yml) for the role is to pull images from [registry.redhat.io](https://registry.redhat.io). The image URL and version can be overridden in the [cr.yaml](../resources/crds/bench_v1alpha1_bench_cr.yaml) file.
 
-You will need to add your Red Hat registry secret to your OpenShift deployment before deploying the
-couchbase infra. To get your Red Hat registry secret, navigate to [registry.redhat.io](https://registry.redhat.io) and
-login. Then click on the **Service Accounts** button, the on your appropriate account name, then on the
-**OpenShift Secret** tab. From there, download or view the \<username\>.secret.yaml file, and
-add the secret to your deployment:
+> In order to pull images from the Red Hat registry, you will need to add a valid Red Hat registry
+> secret to your OpenShift deployment before deploying the couchbase infra. To get your registry
+> secret, navigate to [registry.redhat.io](https://registry.redhat.io) and login. Then click on the **Service Accounts**
+> button, then on your appropriate account name, then on the **OpenShift Secret** tab. From there,
+> download or view the \<username\>.secret.yaml file. This secret is likely encoded for the *registry.redhat.io*
+> URL, though the [couchbase images](https://access.redhat.com/containers/?tab=overview#/registry.connect.redhat.com/couchbase/server) are hosted at *registry.connect.redhat.com*.
+> If you use the downloaded OpenShift secret file, you will need to edit the base64-encoded
+> .dockerconfigjson string to change the registry URL (outside the scope of this document).
+> Otherwise, use the *username* and *password* from the **Token Information** tab to create
+> the secret manually:
 
 ```bash
-# oc create -f \<username\>.secret.yaml
+$ kubectl create secret docker-registry rh-catalog --docker-server=registry.connect.redhat.com \
+  --docker-username=<token_username> --docker-password=<token_password>
+```
+
+> The secret should then be added to the default service account:
+
+```bash
+$ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "<secret_name>"}]}'
 ```
 
 Once you are finished creating/editing the custom resource file, you can run it by:
 
 ```bash
-# kubectl create -f /path/to/bench_v1alpha1_bench_cr.yaml
+$ kubectl create -f /path/to/bench_v1alpha1_bench_cr.yaml
 ```
 
 Deploying the above will first result in the Couchbase operator running (along with a catalog container).
@@ -85,7 +95,7 @@ cb-benchmark-0002   1/1       Running   0          4m18s
 
 You can then confirm the state of the couchbase cluster:
 
-```bash
+```
 $ kubectl describe cbc
 Name:         cb-benchmark
 Namespace:    benchmark

--- a/resources/crds/bench_v1alpha1_bench_cr.yaml
+++ b/resources/crds/bench_v1alpha1_bench_cr.yaml
@@ -41,4 +41,11 @@ spec:
       use_persistent_storage: True
       class_name: "rook-ceph-block"
       volume_size: 10Gi
-    on_openshift: True
+    # Defaults that can be overridden
+    #operator_url: https://www.operatorhub.io/install/preview/couchbase-operator.v1.1.0.yaml
+    # Example for OpenShift (default):
+    #pod_baseImage: registry.connect.redhat.com/couchbase/server
+    #pod_version: 5.5.2-2
+    # Example for or k8s:
+    #pod_baseImage: registry.hub.docker.com/library/couchbase
+    #pod_version: enterprise-6.0.1

--- a/roles/couchbase-infra/defaults/main.yml
+++ b/roles/couchbase-infra/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
-#couchbase: 
-#  servers:
-#    size: 0
+# defaults file for couchbase-infra
+
+operator_url: "{{ couchbase.operator_url | default('https://www.operatorhub.io/install/preview/couchbase-operator.v1.1.0.yaml') }}"
+pod_baseImage: "{{ couchbase.pod_baseImage | default('registry.connect.redhat.com/couchbase/server') }}"
+pod_version: "{{ couchbase.pod_version | default('5.5.2-2') }}"

--- a/roles/couchbase-infra/tasks/main.yml
+++ b/roles/couchbase-infra/tasks/main.yml
@@ -60,7 +60,7 @@
 
 - name: Download Couchbase Operator from operatorhub.io
   get_url:
-    url: "https://www.operatorhub.io/install/couchbase-operator.{{ cb_operator_version }}.yaml"
+    url: "{{ operator_url }}"
     dest: /tmp/cboperator.yaml
 
 - name: Set namespace for Couchbase
@@ -121,6 +121,36 @@
     src: couchbase-cluster.yaml.j2
     dest: /tmp/couchbase-cluster.yaml
     mode: 0640
+
+# Pre-pull the image to avoid CB operator timeout
+- name: Pre-Pull Couchbase Container Image
+  k8s:
+    definition:
+      kind: Job
+      apiVersion: batch/v1
+      metadata:
+        name: cb-image-load
+        namespace: "{{ meta.namespace }}"
+      spec:
+        template:
+          spec:
+            containers:
+            - name: cb-image-load
+              image: "{{ pod_baseImage }}:{{ pod_version }}"
+              command: ['/bin/true']
+            restartPolicy: Never
+        backoffLimit: 4
+
+- name: Wait for Pre-Pull Job to Succeed
+  k8s_facts:
+    kind: Job
+    api_version: batch/v1
+    namespace: "{{ meta.namespace }}"
+    name: cb-image-load
+  register: cb_image_load
+  until: "cb_image_load | json_query('resources[].status.succeeded')"
+  retries: 60
+  delay: 10
 
 - name: Launch Couchbase Cluster from Operator
 #  k8s:

--- a/roles/couchbase-infra/templates/couchbase-cluster.yaml.j2
+++ b/roles/couchbase-infra/templates/couchbase-cluster.yaml.j2
@@ -6,14 +6,9 @@ metadata:
   name: cb-benchmark
   namespace: {{ meta.namespace }}
 spec:
-{% if couchbase.on_openshift %}
   #The upstream image is not compatible with OpenShift
-  baseImage: registry.connect.redhat.com/couchbase/server
-  version: 5.5.2-2
-{% else %}
-  baseImage: registry.hub.docker.com/library/couchbase
-  version: enterprise-6.0.1
-{% endif %}
+  baseImage: {{ pod_baseImage }}
+  version: {{ pod_version }}
   authSecret: cb-example-auth
   exposeAdminConsole: true
   adminConsoleServices:

--- a/roles/couchbase-infra/vars/main.yml
+++ b/roles/couchbase-infra/vars/main.yml
@@ -1,5 +1,1 @@
 ---
-# vars file for bench
-
-# Couchbase operator version to be pulled from operatorhub.io
-cb_operator_version: v1.1.0

--- a/test.sh
+++ b/test.sh
@@ -22,7 +22,7 @@ wait_clean
 /bin/bash tests/test_sysbench.sh
 wait_clean
 #
-# Test Couchbase - (disabled temporarily)
-#/bin/bash tests/test_couchbase.sh
-#wait_clean
+# Test Couchbase
+/bin/bash tests/test_couchbase.sh
+wait_clean
 echo "Smoke test: successful"

--- a/tests/test_couchbase.sh
+++ b/tests/test_couchbase.sh
@@ -39,7 +39,7 @@ function check_cbc () {
   cbc_status="False"
   until [ $cbc_status == "True" ] ; do
     sleep $sleep_time
-    cbc_status=$(kubectl get cbc -o jsonpath='{.items[*].status.conditions.Balanced.status}')
+    cbc_status=$(kubectl get cbc -o jsonpath='{.items[*].status.conditions.Balanced.status}' || echo False)
     if [ -z $cbc_status ]; then
       cbc_status="False"
     fi
@@ -61,13 +61,15 @@ trap finish EXIT
 function functional_test_couchbase {
   apply_operator
   sleep 15
+  kubectl apply -f /root/.1979710-benchmark-operator-ci-pull-secret.yaml
+  kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "1979710-benchmark-operator-ci-pull-secret"}]}'
   kubectl apply -f tests/test_crs/valid_couchbase.yaml
   cb_operator_pod=$(get_pod 'name=couchbase-operator' 300)
   kubectl wait --for=condition=Initialized "pods/$cb_operator_pod" --timeout=60s
   kubectl wait --for=condition=Ready "pods/$cb_operator_pod" --timeout=300s
   cb_app_pod=$(get_pod 'app=couchbase' 600)
   kubectl wait --for=condition=Initialized "pods/$cb_app_pod" --timeout=60s
-  kubectl wait --for=condition=Ready "pods/$cb_app_pod" --timeout=600s
+  kubectl wait --for=condition=Ready "pods/$cb_app_pod" --timeout=300s
   sleep 15
   check_cbc 300
 }

--- a/tests/test_crs/valid_couchbase.yaml
+++ b/tests/test_crs/valid_couchbase.yaml
@@ -9,4 +9,3 @@ spec:
       size: 1
     storage:
       use_persistent_storage: False
-    on_openshift: True


### PR DESCRIPTION
For issue #37 

Adding couchbase deployment

make operator and pod versions and urls variables changeable by CR

move default vars to defaults dir

making operator and pod versions and URLs user-configurable