### PR TITLE
Use Redis for backend key/value store

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,3 +4,7 @@ COPY group_vars/ ${HOME}/group_vars/
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY playbook.yml ${HOME}/playbook.yml
+
+USER root
+RUN yum install -y redis
+USER 1001

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -28,5 +28,23 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ANSIBLE_VERBOSITY
+              value: "4"
             - name: OPERATOR_NAME
               value: "benchmark-operator"
+        - name: redis-master
+          image: k8s.gcr.io/redis:v1
+          env:
+            - name: MASTER
+              value: "true"
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "0.1"
+          volumeMounts:
+            - mountPath: /redis-master-data
+              name: data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/resources/operator_store_results.yaml
+++ b/resources/operator_store_results.yaml
@@ -37,3 +37,19 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "benchmark-operator"
+        - name: redis-master
+          image: k8s.gcr.io/redis:v1
+          env:
+            - name: MASTER
+              value: "true"
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              cpu: "0.1"
+          volumeMounts:
+            - mountPath: /redis-master-data
+              name: data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -43,7 +43,7 @@ function cleanup_operator_resources {
 function update_operator_image {
   operator-sdk build quay.io/rht_perf_ci/benchmark-operator
   docker push quay.io/rht_perf_ci/benchmark-operator
-  sed -i 's|          image: *|          image: quay.io/rht_perf_ci/benchmark-operator:latest # |' resources/operator.yaml
+  sed -i 's|          image: quay.io/benchmark-operator/benchmark-operator:latest*|          image: quay.io/rht_perf_ci/benchmark-operator:latest # |' resources/operator.yaml
 }
 
 


### PR DESCRIPTION
This commit was built to create a mechanism to sync workloads to run at
the sametime. There was a want to do this with FIO, however FIO might
have a built in mechanism to do this. We feel there is still a good
reason to keep this functionality for workloads that do not have built
in sync.