### PR TITLE
change all benchmark.example.com references to ripsaw.cloudbulldozer.io

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -77,7 +77,7 @@ These should be buildable by our CI system for maintaining a central public imag
 
 ### Workload triggers
 [CRD](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) holds the definition of the resource.
-The operator triggers roles based on the conditions defined in [cr](resources/crds/benchmark_v1alpha1_benchmark_cr.yaml) which will influence which roles the
+The operator triggers roles based on the conditions defined in a CR ([example](resources/crds/ripsaw_v1alpha1_uperf_cr.yaml)) which will influence which roles the
 [playbook](playbook.yml) executes.
 Other vars may be defined that can modify the workload run conditions.
 
@@ -85,21 +85,20 @@ For the sake of the example CR, please default all workloads to disabled.
 
 Example CR:
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
   namespace: ripsaw
 spec:
-  <existing_cr_entries>
-  my-new-role:
-    # To disable, set workers to 0
-    workers: 0
-    my_key_1: my_value_1
-    my_key_2: my_value_2
-    my_dict:
-      my_key_3: my_value_3
-    when: my-new-role.condition
+  workload: #can be infrastructure too or can be both like in case of ycsb-couchbase
+    name: your_workload_name
+    args:
+      workers: 0
+      my_key_1: my_value_1
+      my_key_2: my_value_2
+      my_dict:
+        my_key_3: my_value_3
 ```
 
 
@@ -148,11 +147,11 @@ You can then redeploy operator
 ```
 Redefine CRD
 ```bash
-# kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 ```
 Apply a new CR
 ```bash
-# kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_cr.yaml
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
 ```
 
 ## CI

--- a/deploy/20_role.yaml
+++ b/deploy/20_role.yaml
@@ -41,7 +41,7 @@ rules:
   - get
   - create
 - apiGroups:
-  - benchmark.example.com
+  - ripsaw.cloudbulldozer.io
   resources:
   - '*'
   verbs:

--- a/docs/byowl.md
+++ b/docs/byowl.md
@@ -8,7 +8,7 @@ container image with a set of commands.
 Build your CR
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark

--- a/docs/couchbase.md
+++ b/docs/couchbase.md
@@ -15,38 +15,36 @@ Note: Sometimes applying OLM fails on first try, so please retry if it happens.
 ## Running the Couchbase infra
 
 Given that you followed instructions to deploy the benchmark operator,
-you can modify the [cr.yaml](../resources/crds/benchmark_v1alpha1_benchmark_cr.yaml)
+you can modify the [cr.yaml](../resources/crds/ripsaw_v1alpha1_cb_cr.yaml)
 
-Note: Set other roles to 0 to disable them when editing the
-[cr.yaml](../resources/crds/benchmark_v1alpha1_benchmark_cr.yaml) file, or create
-your own custom resource file with only the roles you want defined. An
-example to enable only Couchbase:
+An example to enable only the Couchbase infra (this does _not_ run a workload):
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: couchbase-infra
   namespace: ripsaw
 spec:
-  couchbase:
-    # To disable couchbase, set servers.size to 0
-    # Typical deployment size is 3
-    servers:
-      size: 3
-    storage:
-      use_persistent_storage: True
-      class_name: "rook-ceph-block"
-      volume_size: 10Gi
+  infrastructure:
+    name: couchbase
+    args:
+      servers:
+        # Typical deployment size is 3
+        size: 3
+      storage:
+        use_persistent_storage: True
+        class_name: "rook-ceph-block"
+        volume_size: 10Gi
 ```
 
-If you set `spec.couchbase.stroage.use_persistent_storage` to `true`, then you will need to provide a valid
-StorageClass name for `spec.couchbase.storage.class_name` and a valid volume size for `spec.couchbase.storage.volume_size`.
+If you set `spec.infrastructure.args.stroage.use_persistent_storage` to `true`, then you will need to provide a valid
+StorageClass name for `spec.infrastructure.args.storage.class_name` and a valid volume size for `spec.infrastructure.args.volume_size`.
 
 Setting up a StorageClass is outside the scope of this documentation.
 
 > Note that the upstream couchbase container images will not run on OpenShift as of this build,
-> therefore the [default](../roles/couchbase-infra/defaults/main.yml) for the role is to pull images from [registry.redhat.io](https://registry.redhat.io). The image URL and version can be overridden in the [cr.yaml](../resources/crds/benchmark_v1alpha1_benchmark_cr.yaml) file.
+> therefore the [default](../roles/couchbase-infra/defaults/main.yml) for the role is to pull images from [registry.redhat.io](https://registry.redhat.io). The image URL and version can be overridden in the [cr.yaml](../resources/crds/ripsaw_v1alpha1_cb_cr.yaml) file.
 
 > In order to pull images from the Red Hat registry, you will need to add a valid Red Hat registry
 > secret to your OpenShift deployment before deploying the couchbase infra. To get your registry
@@ -73,7 +71,7 @@ $ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "<secr
 Once you are finished creating/editing the custom resource file, you can run it by:
 
 ```bash
-$ kubectl apply -f /path/to/benchmark_v1alpha1_benchmark_cr.yaml
+$ kubectl apply -f /path/to/cr.yaml
 ```
 
 Deploying the above will first result in the Couchbase operator running (along with a catalog container).
@@ -109,7 +107,7 @@ Metadata:
   Creation Timestamp:  2019-03-21T21:32:45Z
   Generation:          1
   Owner References:
-    API Version:     benchmark.example.com/v1alpha1
+    API Version:     ripsaw.cloudbulldozer.io/v1alpha1
     Kind:            Benchmark
     Name:            example-benchmark
     UID:             c87f2ba3-4c20-11e9-8a78-128d7ee91aa6

--- a/docs/fio.md
+++ b/docs/fio.md
@@ -6,12 +6,12 @@ FIO spawns a number of threads or processes doing a particular type of I/O actio
 
 ## Running FIO Benchmark
 
-Once the operator has been installed following the instructions, one needs to modify the [cr.yaml](../resources/crds/benchmark_v1alpha1_fio_cr.yaml) to run either sequential, random or custom workload. For custom workload one can provide URL of http server where FIO job file is present.
+Once the operator has been installed following the instructions, one needs to modify the [cr.yaml](../resources/crds/ripsaw_v1alpha1_fio_cr.yaml) to run either sequential, random or custom workload. For custom workload one can provide URL of http server where FIO job file is present.
 
-The FIO section in [cr.yaml](../resources/crds/benchmark_v1alpha1_fio_cr.yaml) would look like this.
+The FIO section in [cr.yaml](../resources/crds/ripsaw_v1alpha1_fio_cr.yaml) would look like this.
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
@@ -31,12 +31,12 @@ spec:
     storagesize: 30Gi # Provide if PV is needed
 ```
 
-Note: Please ensure to set 0 for other workloads if editing the [cr.yaml](../resources/crds/benchmark_v1alpha1_fio_cr.yaml) file otherwise desired workload won't be executed. If storage class is defined we can provide persistent volume (PV) to the POD where FIO test will be executed.
+Note: Please ensure to set 0 for other workloads if editing the [cr.yaml](../resources/crds/ripsaw_v1alpha1_fio_cr.yaml) file otherwise desired workload won't be executed. If storage class is defined we can provide persistent volume (PV) to the POD where FIO test will be executed.
 
 Once done creating/editing the resource file, one can run it by:
 
 ```bash
-# kubectl apply -f resources/crds/benchmark_v1alpha1_fio_cr.yaml # if edited the original one
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_fio_cr.yaml # if edited the original one
 # kubectl apply -f <path_to_file> # if created a new cr file
 ```
 
@@ -50,7 +50,7 @@ example-benchmark-fio-client-1-benchmark   1/1       Running   0          22s
 example-benchmark-fio-client-2-benchmark   1/1       Running   0          22s
 ```
 
-Since we have storageclass and storagesize defined in [cr.yaml](../resources/crds/benchmark_v1alpha1_fio_cr.yaml) file, the corresponding status of persitent volume is seen like this:
+Since we have storageclass and storagesize defined in [cr.yaml](../resources/crds/ripsaw_v1alpha1_fio_cr.yaml) file, the corresponding status of persitent volume is seen like this:
 
 ```bash
 kubectl get pv

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -11,7 +11,7 @@ workload.
 Build your CR for Distributed FIO
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: fio-benchmark

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ We'll now apply the permissions and operator definitions.
 
 ```bash
 # kubectl apply -f deploy
-# kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 # kubectl apply -f resources/operator.yaml
 ```
 
@@ -79,7 +79,7 @@ stored in [operator_store_results](../resources/operator_store_results.yaml) aft
 as follows:
 ```bash
 # kubectl apply -f resources/result-pvc.yaml
-# kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 # kubectl apply -f resources/operator_store_results.yaml
 ```
 
@@ -99,8 +99,8 @@ If you want to add a new workload please follow these [instructions](../CONTRIBU
 Now that we're running workloads we can cleanup by running following commands
 
 ```bash
-# kubectl delete -f resources/crds/benchmark_v1alpha1_benchmark_cr.yaml # if not already done and assuming this was the resource file passed
-# kubectl delete -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+# kubectl delete -f <your_cr_file>
+# kubectl delete -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 # kubectl delete -f resources/operator.yaml
 # kubectl delete -f deploy
 ```

--- a/docs/sysbench.md
+++ b/docs/sysbench.md
@@ -5,24 +5,33 @@
 ## Running Sysbench
 
 Given that you followed instructions to deploy operator,
-you can modify [cr.yaml](../resources/crds/benchmark_v1alpha1_benchmark_cr.yaml)
+you can modify [cr.yaml](../resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml)
 
 Note: please ensure you set 0 for other workloads if editing the
-[cr.yaml](../resources/crds/benchmark_v1alpha1_benchmark_cr.yaml) file otherwise
-your resource file should look like this:
+[cr.yaml](../resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml) file otherwise
+
+your resource file may look like this:
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: sysbench-benchmark
   namespace: ripsaw
 spec:
-  enabled: true
-  tests:
-  - name: cpu
-    parameters:
-      cpu-max-prime: 200
+  workload:
+    name: sysbench
+    args:
+      enabled: true
+      #kind: vm
+      # If you want to run this as a VM uncomment the above
+      tests:
+      - name: cpu
+        parameters:
+          cpu-max-prime: 2000
+      - name: fileio
+        parameters:
+          file-test-mode: rndrw
 ```
 
 Name here refers to testname and can be cpu or fileio or memory etc and the parameters are the parametes for the particular test.
@@ -31,7 +40,7 @@ You can find more information at [sysbench documentation](https://github.com/ako
 Once done creating/editing the resource file, you can run it by:
 
 ```bash
-# kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_cr.yaml # if edited the original one
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml # if edited the original one
 # kubectl apply -f <path_to_file> # if created a new cr file
 ```
 

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -5,32 +5,33 @@
 ## Running UPerf
 
 Given that you followed instructions to deploy operator,
-you can modify [cr.yaml](../resources/crds/benchmark_v1alpha1_uperf_cr.yaml)
+you can modify [cr.yaml](../resources/crds/ripsaw_v1alpha1_uperf_cr.yaml)
 
 Note: please ensure you set 0 for other workloads if editing the
-[cr.yaml](../resources/crds/benchmark_v1alpha1_uperf_cr.yaml) file otherwise
+[cr.yaml](../resources/crds/ripsaw_v1alpha1_uperf_cr.yaml) file otherwise
 your resource file should look like this:
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-benchmark
   namespace: ripsaw
 spec:
-  name: uperf
-  args:
-    hostnetwork: false
-    pin: true
-    pin_server: "master-0"
-    pin_client: "master-1"
-    # Server size must always be 1 or more
-    pairs: 1
-    proto: tcp
-    test_type: stream
-    nthr: 2
-    size: 16384
-    runtime: 60
+  workload:
+    name: uperf
+    args:
+      hostnetwork: false
+      pin: true
+      pin_server: "master-0"
+      pin_client: "master-1"
+      # Server size must always be 1 or more
+      pairs: 1
+      proto: tcp
+      test_type: stream
+      nthr: 2
+      size: 16384
+      runtime: 60
 ```
 
 `hostnetwork` will test the performance of the node the pod will run on.
@@ -52,7 +53,7 @@ $ oc adm policy add-scc-to-user privileged -z benchmark-operator
 Once done creating/editing the resource file, you can run it by:
 
 ```bash
-# kubectl apply -f deploy/crds/benchmark_v1alpha1_benchmark_cr.yaml # if edited the original one
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_uperf_cr.yaml # if edited the original one
 # kubectl apply -f <path_to_file> # if created a new cr file
 ```
 
@@ -61,7 +62,7 @@ instructions to deploy operator with attached pvc and would like to send results
 you can instead define a custom resource as follows:
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/docs/ycsb.md
+++ b/docs/ycsb.md
@@ -5,11 +5,10 @@
 ## Running YCSB
 
 Given that you followed instructions to deploy operator,
-you can modify [cr.yaml](../deploy/crds/benchmark_v1alpha1_benchmark_cr.yaml)
+you can modify [cr.yaml](../resources/crds/ripsaw_v1alpha1_ycsb-cb_cr.yaml) to your needs.
 
-Note: please ensure you set 0 for other workloads if editing the
-[cr.yaml](../deploy/crds/benchmark_v1alpha1_benchmark_cr.yaml) file otherwise
-your resource file should look like this:
+> NOTE: The above example CR deploys both the Couchbase infra and runs the YCSB benchmark on it.
+
 
 YCSB is a workload that requires a kubernetes self-hosted infrastructure on which to run its tests. The CR structure requires you to define the infra. Current infra systems deployable by the benchmark operator and supported for YCSB testing:
 
@@ -18,37 +17,38 @@ YCSB is a workload that requires a kubernetes self-hosted infrastructure on whic
 | Couchbase      | Working        |
 | MongoDB        | Planned        |
 
+Your resource file may look like this:
 
 ```yaml
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-bench
+  name: ycsb-couchbase-benchmark
   namespace: ripsaw
 spec:
-  couchbase:
-    # To disable couchbase, set servers.size to 0
-    # Typical deployment size is 3
-    servers:
-      size: 3
-    storage:
-      use_persistent_storage: True
-      class_name: "rook-ceph-block"
-      volume_size: 10Gi
-    on_openshift: True
-  ycsb:
-    # To disable ycsb, set workers to 0
-    # ycsb must be loaded after the infra it depends on
-    workers: 1
-    infra: couchbase
-    driver: couchbase2
-    workload: workloada
+  infrastructure:
+    name: couchbase
+    args:
+      servers:
+        # Typical deployment size is 3
+        size: 3
+      storage:
+        use_persistent_storage: True
+        class_name: "rook-ceph-block"
+        volume_size: 10Gi
+  workload:
+    name: ycsb
+    args:
+      workers: 1
+      infra: couchbase
+      driver: couchbase2
+      workload: workloada
 ```
 
 Once done creating/editing the resource file, you can run it by:
 
 ```bash
-# kubectl apply -f deploy/crds/benchmark_v1alpha1_benchmark_cr.yaml # if edited the original one
+# kubectl apply -f resources/crds/ripsaw_v1alpha1_ycsb-cb_cr.yaml # if edited the original one
 # kubectl apply -f <path_to_file> # if created a new cr file
 ```
 

--- a/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
@@ -8,7 +8,7 @@ spec:
     name: byowl
     args:
       image: "quay.io/jtaleric/uperf:testing"
-      clients: 0
+      clients: 1
       commands: |
         echo 'Test';
         echo 'Test2'

--- a/resources/crds/ripsaw_v1alpha1_cb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_cb_cr.yaml
@@ -1,0 +1,16 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: couchbase-infra
+  namespace: ripsaw
+spec:
+  infrastructure:
+    name: couchbase
+    args:
+      servers:
+        # Typical deployment size is 3
+        size: 3
+      storage:
+        use_persistent_storage: True
+        class_name: "rook-ceph-block"
+        volume_size: 10Gi

--- a/resources/crds/ripsaw_v1alpha1_fio_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
@@ -8,7 +8,7 @@ spec:
     name: fio
     args:
       job: seq # either of  seq, rand or custom
-      clients: 0 #specify number of clients on which FIO should run
+      clients: 1 #specify number of clients on which FIO should run
       jobname: seq # either of seq, rand or custom
       get_url:  #If Job is custom, provide URL of job here 
       bs: 4k # provide only if job is seq or rand

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: benchmarks.benchmark.example.com
+  name: benchmarks.ripsaw.cloudbulldozer.io
 spec:
-  group: benchmark.example.com
+  group: ripsaw.cloudbulldozer.io
   names:
     kind: Benchmark
     listKind: BenchmarkList

--- a/resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml
@@ -1,13 +1,13 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: sysbench-benchmark
   namespace: ripsaw
 spec:
   workload:
     name: sysbench
     args:
-      enabled: false
+      enabled: true
       #kind: vm
       # If you want to run this as a VM uncomment the above
       tests:

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -1,7 +1,7 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: uperf-benchmark
   namespace: ripsaw
 spec:
   workload:
@@ -13,7 +13,7 @@ spec:
       pin_server: "server_hostname"
       pin_client: "client_hostname"
       rerun: 1
-      pair: 0
+      pair: 1
       proto: tcp
       test_type: stream
       nthr: 2

--- a/resources/crds/ripsaw_v1alpha1_ycsb-cb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ycsb-cb_cr.yaml
@@ -1,14 +1,15 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: ycsb-couchbase-benchmark
   namespace: ripsaw
 spec:
   infrastructure:
     name: couchbase
     args:
       servers:
-        size: 0
+        # Typical deployment size is 3
+        size: 3
       storage:
         use_persistent_storage: True
         class_name: "rook-ceph-block"
@@ -16,7 +17,7 @@ spec:
   workload:
     name: ycsb
     args:
-      workers: 0
+      workers: 1
       infra: couchbase
       driver: couchbase2
       workload: workloada

--- a/roles/result/templates/result.json
+++ b/roles/result/templates/result.json
@@ -1,7 +1,7 @@
 {
   "uuid": "{{ item.item | regex_replace('-.*','') | to_uuid }}",
   "user": "{{user}}",
-  "spec": {{  _benchmark_example_com_benchmark.spec | to_nice_json  }},
+  "spec": {{  _ripsaw_cloudbulldozer_io_benchmark.spec | to_nice_json  }},
   "result": "{{ item.content }}",
   "time_start": "{{ item.item | regex_replace('-.*','') }}"
 }

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -20,7 +20,7 @@ function delete_operator {
 
 function operator_requirements {
   kubectl apply -f deploy
-  kubectl apply -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+  kubectl apply -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 }
 
 function create_operator {
@@ -30,7 +30,7 @@ function create_operator {
 
 function cleanup_resources {
   echo "Exiting after cleanup of resources"
-  kubectl delete -f resources/crds/benchmark_v1alpha1_benchmark_crd.yaml
+  kubectl delete -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
   kubectl delete -f deploy
 }
 

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark

--- a/tests/test_crs/valid_couchbase.yaml
+++ b/tests/test_crs/valid_couchbase.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_fio.yaml
+++ b/tests/test_crs/valid_fio.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_uperf_store.yaml
+++ b/tests/test_crs/valid_uperf_store.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark

--- a/tests/test_crs/valid_ycsb-couchbase.yaml
+++ b/tests/test_crs/valid_ycsb-couchbase.yaml
@@ -1,4 +1,4 @@
-apiVersion: benchmark.example.com/v1alpha1
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-bench

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,5 +1,5 @@
 ---
 - version: v1alpha1
-  group: benchmark.example.com
+  group: ripsaw.cloudbulldozer.io
   kind: Benchmark
   playbook: /opt/ansible/playbook.yml


### PR DESCRIPTION
rename files to match new ripsaw.cloudbulldozer.io domain
fix names, update docs, and default CRs to on

We own cloudbulldozer.io now!