### PR TITLE
Indent properly volumes for operator container

### DIFF
--- a/resources/operator_store_results.yaml
+++ b/resources/operator_store_results.yaml
@@ -13,10 +13,6 @@ spec:
       labels:
         name: benchmark-operator
     spec:
-      volumes:
-      - name: result-data
-        persistentVolumeClaim:
-          claimName: result-volume
       serviceAccountName: benchmark-operator
       containers:
         - name: benchmark-operator
@@ -53,3 +49,6 @@ spec:
       volumes:
         - name: data
           emptyDir: {}
+        - name: result-data
+          persistentVolumeClaim:
+            claimName: result-volume


### PR DESCRIPTION
result-data volume was not indented properly in the operator Deployment. I was getting this error:

```
oc create -f resources/operator_store_results.yaml                                                                                                                                                                                                

The Deployment "benchmark-operator" is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found: "result-data" 
```