### PR TITLE
Updating image tag to master

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -109,7 +109,7 @@ to [uperf](docs/uperf.md)
 * Add the link for your workload guide to [installation guide](docs/installation.md#running-workloads)
 * Ensure all resources created are within the `ripsaw` namespace, this can be done by setting namespace
 to use `operator_namespace` var. This is to ensure that the resources aren't defaulted to current active
-namespace which is what `meta.namespace` would default to. 
+namespace which is what `meta.namespace` would default to.
 
 ### Best practices for new workloads
 The following steps are suggested for your workload to be added:
@@ -129,7 +129,7 @@ $ operator-sdk build quay.io/<username>/benchmark-operator:testing
 $ docker push quay.io/<username>/benchmark-operator:testing
 ```
 
-`:testing` is simply a tag. You can define different tags to use with your image, like `:latest`
+`:testing` is simply a tag. You can define different tags to use with your image, like `:latest` or `:master`
 
 To test with your own operator image, you will need the [operator](resources/operator.yml) file to point the container image to your testing version.
 Be sure to do this outside of your git tree to avoid mangling the official file that points to our stable image.

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: benchmark-operator
           # Replace this with the built image name
-          image: quay.io/benchmark-operator/benchmark-operator:latest
+          image: quay.io/benchmark-operator/benchmark-operator:master
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/resources/operator_store_results.yaml
+++ b/resources/operator_store_results.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: benchmark-operator
           # Replace this with the built image name
-          image: quay.io/benchmark-operator/benchmark-operator:latest
+          image: quay.io/benchmark-operator/benchmark-operator:master
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: "/opt/result-data/"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -68,7 +68,7 @@ function update_operator_image {
   tag_name="${NODE_NAME:-master}"
   operator-sdk build quay.io/rht_perf_ci/benchmark-operator:$tag_name
   docker push quay.io/rht_perf_ci/benchmark-operator:$tag_name
-  sed -i "s|          image: quay.io/benchmark-operator/benchmark-operator:latest*|          image: quay.io/rht_perf_ci/benchmark-operator:$tag_name # |" resources/operator.yaml
+  sed -i "s|          image: quay.io/benchmark-operator/benchmark-operator:master*|          image: quay.io/rht_perf_ci/benchmark-operator:$tag_name # |" resources/operator.yaml
 }
 
 


### PR DESCRIPTION
Moving to use quay.io trigger for git push, this would mean that the tag
will be updated to branch name.

Also updated documentation and operator definition to pull from master tag.