### PR TITLE
UPerf : Pod to Service

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -17,6 +17,7 @@ spec:
   workload:
     name: uperf
     args:
+      serviceip: false
       hostnetwork: false
       pin: false
       pin_server: "node-0"
@@ -31,6 +32,8 @@ spec:
         - 16384
       runtime: 30
 ```
+
+`serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 
 `hostnetwork` will test the performance of the node the pod will run on.
 

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -8,6 +8,7 @@ spec:
     # cleanup: true
     name: uperf
     args:
+      serviceip: false
       hostnetwork: false
       pin: false
       pin_server: "node-0"

--- a/resources/crds/ripsaw_v1alpha1_uperf_index_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_index_cr.yaml
@@ -12,6 +12,7 @@ spec:
     # cleanup: true
     name: uperf
     args:
+      serviceip: false
       hostnetwork: false
       pin: false
       pin_server: "node-0"

--- a/roles/uperf-bench/tasks/main.yml
+++ b/roles/uperf-bench/tasks/main.yml
@@ -50,6 +50,12 @@
     msg: "Check : {{curr_values}} vs {{prev_values}}"
   when: state_file.stat.exists == true
 
+- name: Create service for server pods
+  k8s:
+    definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
+  with_sequence: start=0 count={{uperf.pair}}
+  when: uperf.serviceip
+
 - block:
 
   - name: Start Server(s)
@@ -64,11 +70,19 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - app = uperf-bench-server
+        - type = uperf-bench-server
     register: server_pods
     until: "'Running' in (server_pods | json_query('resources[].status.phase'))"
     retries: 10
     delay: 10
+
+  - name: Capture ServiceIP
+    k8s_facts:
+      kind: Service
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+    register: serviceip
+    when: uperf.serviceip
 
   - name: Capture operator information
     k8s_facts:
@@ -87,7 +101,13 @@
     k8s:
       definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
     with_items: "{{ server_pods.resources }}"
-    when: server_pods.resources|length > 0
+    when: not uperf.serviceip and server_pods.resources|length > 0
+
+  - name: Start Client(s) - ServiceIP
+    k8s:
+      definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+    with_items: "{{ serviceip.resources }}"
+    when: uperf.serviceip and serviceip.resources|length > 0
 
   - name: Check if all clients are up
     k8s_facts:

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -2,21 +2,28 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: '{{ meta.name }}-uperf-server-{{item}}'
+  name: 'uperf-server-{{item}}'
   namespace: '{{ operator_namespace }}'
   labels:
-    app : uperf-bench-server
+    app : uperf-bench-server-{{item}}
+    type : uperf-bench-server
 spec:
-{% if uperf.hostnetwork %}
+{% if uperf.hostnetwork is sameas true %}
   hostNetwork : true
 {% endif %}
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/uperf:latest"
-    command: ["/bin/sh", "-c"]
-    args: ["uperf -s"]
+    command: ["/bin/sh","-c"]
+    args: ["uperf -s -v -P 20000"]
   restartPolicy: OnFailure
-{% if uperf.pin %}
+{% if uperf.pin is sameas true %}
   nodeSelector:
     kubernetes.io/hostname: '{{ uperf.pin_server }}'
+{% endif %}
+{% if uperf.serviceip is sameas true %}
+  securityContext:
+    sysctls:
+    - name: net.ipv4.ip_local_port_range
+      value: 20000 20011
 {% endif %}

--- a/roles/uperf-bench/templates/service.yml.j2
+++ b/roles/uperf-bench/templates/service.yml.j2
@@ -1,0 +1,24 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: uperf-service-{{item}}
+  namespace: '{{ operator_namespace }}'
+spec:
+  selector:
+    app: uperf-bench-server-{{item}}
+  ports:
+  - name: uperf
+    port: 20000
+    targetPort: 20000
+    protocol: TCP
+{% for num in range(20001,20011,1) %}
+  - name: uperf-control-tcp-{{num}}
+    port: {{num}}
+    targetPort: {{num}}
+    protocol: TCP
+  - name: uperf-control-udp-{{num}}
+    port: {{num}}
+    targetPort: {{num}}
+    protocol: UDP
+{% endfor %}

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -2,16 +2,19 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
-  name: '{{ meta.name }}-uperf-client-{{item.status.podIP}}'
+{% if uperf.serviceip is sameas true %}
+  name: 'uperf-client-{{item.spec.clusterIP}}'
+{% else %}
+  name: 'uperf-client-{{item.status.podIP}}'
+{% endif %}
   namespace: '{{ operator_namespace }}'
 spec:
-  ttlSecondsAfterFinished: 600
   template:
     metadata:
       labels:
         app: uperf-bench-client
     spec:
-{% if uperf.hostnetwork %}
+{% if uperf.hostnetwork is sameas true %}
       hostNetwork : true
       serviceAccountName: benchmark-operator
       serviceAccount: benchmark-operator
@@ -21,7 +24,12 @@ spec:
         image: "quay.io/cloud-bulldozer/uperf:latest"
         command: ["/bin/sh", "-c"]
         args:
+{% if uperf.serviceip is sameas true %}
+          - "export serviceip=true;
+             export h={{item.spec.clusterIP}};
+{% else %}
           - "export h={{item.status.podIP}};
+{% endif %}
 {% if elasticsearch is defined %}
 {% if elasticsearch.server is defined %}
              export es={{elasticsearch.server}};
@@ -56,7 +64,7 @@ spec:
           configMap:
             name: uperf-test
       restartPolicy: OnFailure
-{% if uperf.pin %}
+{% if uperf.pin is sameas true %}
       nodeSelector:
           kubernetes.io/hostname: '{{ uperf.pin_client }}'
 {% endif %}

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -9,6 +9,7 @@ spec:
     name: uperf
     args:
       hostnetwork: false
+      serviceip: false
       pin: false
       pin_server: "node-0"
       pin_client: "node-1"

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+source tests/common.sh
+
+function finish {
+  echo "Cleaning up Uperf"
+  kubectl delete -f tests/test_crs/valid_uperf_serviceip.yaml
+  delete_operator
+}
+
+trap finish EXIT
+
+function functional_test_uperf_serviceip {
+  apply_operator
+  kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
+  check_pods 2
+  uperf_client_pod=$(kubectl get pods -l app=uperf-bench-client -o name | cut -d/ -f2)
+  kubectl wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
+  kubectl wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
+  #check_log $uperf_client_pod "Success"
+  # This is for the operator playbook to finish running
+  sleep 30
+  kubectl get pods -l name=benchmark-operator --namespace ripsaw -o name | cut -d/ -f2 | xargs -I{} kubectl exec {} -- cat /tmp/current_run
+
+  # ensuring that uperf actually ran and we can access metrics
+  kubectl logs "$uperf_client_pod" --namespace ripsaw | grep Success
+  echo "Uperf test: Success"
+}
+functional_test_uperf_serviceip


### PR DESCRIPTION
UPerf uses mutliple ports, which makes things a bit tricky for using K8s
services. Since with services you need to define the ports in use.

By default UPerf will use port `20000` for data plane, but then it opens
another port random(35000,4XXXX?) for control it seems. Orgionally I
was using using Jinja to create thousands of ports to open in the
service definiton, however that caused issues with the server pod.
Instead I limited the ports that were availabile for use to
20001->20041 for the control.

fixes #24