### PR TITLE
Improve CI pod checking, including ripsaw itself

### DIFF
--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -12,10 +12,10 @@ function finish {
 trap finish EXIT
 
 function functional_test_byowl {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
-  check_pods 1
-  byowl_pod=$(kubectl -n ripsaw get pods -l app=byowl -o name | cut -d/ -f2)
+  byowl_pod=$(get_pod 'app=byowl' 300)
   kubectl -n ripsaw wait --for=condition=Initialized "pods/$byowl_pod" --timeout=200s
   kubectl -n ripsaw  wait --for=condition=complete -l app=byowl jobs
   kubectl logs "$byowl_pod" | grep "Test"

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -2,6 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark
+  namespace: ripsaw
 spec:
   workload:
     name: byowl

--- a/tests/test_fio.sh
+++ b/tests/test_fio.sh
@@ -12,10 +12,10 @@ function finish {
 trap finish EXIT
 
 function functional_test_fio {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_fio.yaml
-  check_pods 1
-  fio_pod=$(kubectl get pods -l app=fio-benchmark --namespace ripsaw -o name | cut -d/ -f2)
+  fio_pod=$(get_pod 'app=fio-benchmark' 300)
   kubectl wait --for=condition=Initialized "pods/$fio_pod" --namespace ripsaw --timeout=200s
   kubectl wait --for=condition=complete -l app=fio-benchmark jobs --namespace ripsaw --timeout=100s
   sleep 30

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -12,10 +12,11 @@ function finish {
 trap finish EXIT
 
 function functional_test_fio {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_fiod.yaml
-  check_pods 3
-  fio_pod=$(kubectl get pods -l app=fiod-client --namespace ripsaw -o name | cut -d/ -f2)
+  pod_count 'app=fio-benchmark' 2 300
+  fio_pod=$(get_pod 'app=fiod-client' 300)
   kubectl wait --for=condition=Initialized "pods/$fio_pod" --namespace ripsaw --timeout=200s
   kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace ripsaw --timeout=300s
   sleep 30

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -12,10 +12,11 @@ function finish {
 trap finish EXIT
 
 function functional_test_iperf {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
-  check_pods 2
-  iperf_client_pod=$(kubectl -n ripsaw get pods -l app=iperf3-bench-client -o name | cut -d/ -f2)
+  pod_count 'app=iperf3-bench-server' 1 300
+  iperf_client_pod=$(get_pod 'app=iperf3-bench-client' 300)
   kubectl -n ripsaw wait --for=condition=Initialized "pods/$iperf_client_pod" --timeout=200s
   kubectl -n ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s
   sleep 5
@@ -23,4 +24,5 @@ function functional_test_iperf {
   kubectl logs "$iperf_client_pod" --namespace ripsaw | grep "iperf Done."
   echo "iperf test: Success"
 }
+
 functional_test_iperf

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -12,10 +12,10 @@ function finish {
 trap finish EXIT
 
 function functional_test_sysbench {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
-  check_pods 1
-  sysbench_pod=$(kubectl get pods -l app=sysbench --namespace ripsaw -o name | cut -d/ -f2)
+  sysbench_pod=$(get_pod 'app=sysbench' 300)
   kubectl wait --for=condition=Initialized "pods/$sysbench_pod" --namespace ripsaw --timeout=200s
   # Higher timeout as it takes longer
   kubectl wait --for=condition=complete -l app=sysbench --namespace ripsaw jobs

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -12,10 +12,11 @@ function finish {
 trap finish EXIT
 
 function functional_test_uperf {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf.yaml
-  check_pods 2
-  uperf_client_pod=$(kubectl -n ripsaw get pods -l app=uperf-bench-client -o name | cut -d/ -f2)
+  pod_count 'type=uperf-bench-server' 1 300
+  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
   kubectl -n ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
   kubectl -n ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
   #check_log $uperf_client_pod "Success"

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -12,10 +12,11 @@ function finish {
 trap finish EXIT
 
 function functional_test_uperf_serviceip {
+  #figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
-  check_pods 2
-  uperf_client_pod=$(kubectl get pods -l app=uperf-bench-client -o name | cut -d/ -f2)
+  pod_count 'type=uperf-bench-server' 1 300
+  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
   kubectl wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
   kubectl wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
   #check_log $uperf_client_pod "Success"


### PR DESCRIPTION
This adds a `git_pod()` function to `common.sh` that is more robust than the existing `check_pods()` function. It also uses the new function to validate the ripsaw pod before allowing the test CR to be applied. All test scripts are updated to use the new function.