### PR TITLE
Stop waiting for ripsaw crd to delete when cleaning up

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -52,7 +52,7 @@ function create_operator {
 
 function cleanup_resources {
   echo "Exiting after cleanup of resources"
-  kubectl delete -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+  kubectl delete -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml --wait=false
   kubectl delete -f deploy
 }
 


### PR DESCRIPTION
Added --wait=false when deleting ripsaw crd as it was frequently hanging during CI.