### PR TITLE
updating namespace to my-ripsaw

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -93,7 +93,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload: #can be infrastructure too or can be both like in case of ycsb-couchbase
     name: your_workload_name
@@ -105,13 +105,14 @@ spec:
         my_key_3: my_value_3
 ```
 
+Note: The Benchmark has to be created in the namespace `my-ripsaw`
 
 ### Additional guidance for adding a workload
 * Please keep the [workload status](README.md#workloads-status) updated
 * To help users understand how the workload can be run, please add a guide similar
 to [uperf](docs/uperf.md)
 * Add the link for your workload guide to [installation guide](docs/installation.md#running-workloads)
-* Ensure all resources created are within the `ripsaw` namespace, this can be done by setting namespace
+* Ensure all resources created are within the `my-ripsaw` namespace, this can be done by setting namespace
 to use `operator_namespace` var. This is to ensure that the resources aren't defaulted to current active
 namespace which is what `meta.namespace` would default to.
 

--- a/deploy/10_service_account.yaml
+++ b/deploy/10_service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw

--- a/deploy/20_role.yaml
+++ b/deploy/20_role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw
 rules:
 - apiGroups:
   - ""

--- a/deploy/30_role_binding.yaml
+++ b/deploy/30_role_binding.yaml
@@ -2,11 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw
 subjects:
 - kind: ServiceAccount
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw
 roleRef:
   kind: Role
   name: benchmark-operator

--- a/docs/byowl.md
+++ b/docs/byowl.md
@@ -12,6 +12,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark
+  namespace: my-ripsaw
 spec:
   byowl:
     image: "quay.io/jtaleric/uperf:testing"
@@ -23,4 +24,3 @@ spec:
 
 This will launch the uperf container, and simply print the messages
 above into the log of the container.
-

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -14,7 +14,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: fio-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: "fio_distributed"
@@ -95,7 +95,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   elasticsearch:
     server: <es_host>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,9 @@ in the installation guide.
 Note: The benchmark-operator's code-name is ripsaw, so the names have been
 used interchangeably.
 
+Note: If you're on a vanilla k8s distribution, then you can also deploy Ripsaw through
+      operatorhub.io, please check [ripsaw in operatorhub](https://operatorhub.io/operator/ripsaw) for more details.
+
 First we'll need to clone the operator:
 
 ```bash
@@ -54,15 +57,21 @@ First we'll need to clone the operator:
 # export KUBECONFIG=<your_kube_config> # if not already done
 ```
 
-We try to maintain all resources created/required by ripsaw in the namespace
-ripsaw, so we'll create the namespace and add a context with admin user and
-can be done as follows:
+We try to maintain all resources created/required by ripsaw in the namespace `my-ripsaw`,
+as this would be the namespace, ripsaw would be installed into if deployed through operatorhub.io.
+
+Note: But in case you've a specific usecase where you want the resources to be in a different namespace, you'll just need to edit the namespace in deploy/
+as well as the operator definition.
+
+But for sake of the documentation, let's proceed with the namespace `my-ripsaw`
+
+so we'll create the namespace as follows
 
 ```bash
 # kubectl apply -f resources/namespace.yaml
-# kubectl config set-context ripsaw --namespace=ripsaw --cluster=<your_cluster_name> --user=<your_cluster_admin_user>
-# kubectl config use-context ripsaw
 ```
+
+or if you're used to `oc` it'd be `oc new-project my-ripsaw` and `oc project my-ripsaw`
 
 We'll now apply the permissions and operator definitions.
 

--- a/docs/iperf.md
+++ b/docs/iperf.md
@@ -13,7 +13,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: iperf3-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   name: iperf3
   args:

--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -16,7 +16,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: pgbench-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: "pgbench"
@@ -50,18 +50,18 @@ spec:
       #test_sequential: False
 
       ## List of databases to test
-      # Note: 'databases' below is a list structures to identify multiple 
+      # Note: 'databases' below is a list structures to identify multiple
       #       databases against which benchmarks tests will be run
       databases:
         - host:  # hostname or IP
-          user: 
+          user:
           # FIXME: Get passwords other than by plain text here
-          password: 
-          db_name: 
+          password:
+          db_name:
           # port will default to 5432 if left blank or undefined
           port:  
           # pin_node is an optional kubernetes hostname to which the pgbench pod will be pinned
-          pin_node: 
+          pin_node:
 ```
 
 Once done creating/editing the resource file, you can run it by:

--- a/docs/smallfile.md
+++ b/docs/smallfile.md
@@ -10,7 +10,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: smallfile
@@ -31,7 +31,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: smallfile

--- a/docs/sysbench.md
+++ b/docs/sysbench.md
@@ -17,7 +17,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: sysbench-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: sysbench

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -12,7 +12,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: uperf
@@ -84,7 +84,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   test_user: test_user # user is a key that points to user triggering ripsaw, useful to search results in ES
   elasticsearch:

--- a/docs/ycsb.md
+++ b/docs/ycsb.md
@@ -15,7 +15,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: ycsb-mongo-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: ycsb

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,2 +1,2 @@
 ---
-operator_namespace: ripsaw
+operator_namespace: '{{ meta.namespace }}'

--- a/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: byowl

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: "fio_distributed"

--- a/resources/crds/ripsaw_v1alpha1_iperf3_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_iperf3_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: iperf3-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   name: iperf3
   args:

--- a/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: pgbench-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: "pgbench"
@@ -38,27 +38,27 @@ spec:
       #test_sequential: False
 
       ## List of databases to test
-      # Note: 'databases' below is a list structures to identify multiple 
+      # Note: 'databases' below is a list structures to identify multiple
       #       databases against which benchmarks tests will be run
       databases:
         - host:  # hostname or IP
-          user: 
+          user:
           # FIXME: Get passwords other than by plain text here
-          password: 
-          db_name: 
+          password:
+          db_name:
           # port will default to 5432 if left blank or undefined
-          port:  
+          port:
           # pin_node is an optional kubernetes hostname to which the pgbench pod will be pinned
-          pin_node: 
+          pin_node:
         #- host:
         #  user:
         #  password:
         #  db_name:
-        #  port: 
+        #  port:
         #  pin_node:
         #- host:
         #  user:
         #  password:
         #  db_name:
-        #  port: 
+        #  port:
         #  pin_node:

--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: smallfile

--- a/resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: sysbench-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: sysbench

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     # cleanup: true

--- a/resources/crds/ripsaw_v1alpha1_uperf_index_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_index_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: uperf-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   #elasticsearch:
   #   server: elk.server.com

--- a/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: ycsb-couchbase-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: ycsb

--- a/resources/namespace.yaml
+++ b/resources/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ripsaw
+  name: my-ripsaw

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   replicas: 1
   selector:

--- a/resources/operator_store_results.yaml
+++ b/resources/operator_store_results.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: benchmark-operator
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   replicas: 1
   selector:

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -25,11 +25,11 @@ function populate_test_list {
 }
 
 function wait_clean {
-  kubectl delete --all jobs --namespace ripsaw
-  kubectl delete --all deployments --namespace ripsaw
-  kubectl delete --all pods --namespace ripsaw
+  kubectl delete --all jobs --namespace my-ripsaw
+  kubectl delete --all deployments --namespace my-ripsaw
+  kubectl delete --all pods --namespace my-ripsaw
   for i in {1..30}; do
-    if [ `kubectl get pods --namespace ripsaw | grep bench | wc -l` -ge 1 ]; then
+    if [ `kubectl get pods --namespace my-ripsaw | grep bench | wc -l` -ge 1 ]; then
       sleep 5
     else
       break
@@ -45,7 +45,7 @@ function get_pod () {
   pod_name="False"
   until [ $pod_name != "False" ] ; do
     sleep $sleep_time
-    pod_name=$(kubectl get pods -l $1 --namespace ripsaw -o name | cut -d/ -f2)
+    pod_name=$(kubectl get pods -l $1 --namespace my-ripsaw -o name | cut -d/ -f2)
     if [ -z $pod_name ]; then
       pod_name="False"
     fi
@@ -67,7 +67,7 @@ function pod_count () {
   export $1
   until [ $pod_count == $2 ] ; do
     sleep $sleep_time
-    pod_count=$(kubectl get pods -n ripsaw -l $1 -o name | wc -l)
+    pod_count=$(kubectl get pods -n my-ripsaw -l $1 -o name | wc -l)
     if [ -z $pod_count ]; then
       pod_count=0
     fi
@@ -83,8 +83,8 @@ function pod_count () {
 function apply_operator {
   kubectl apply -f resources/operator.yaml
   ripsaw_pod=$(get_pod 'name=benchmark-operator' 300)
-  kubectl wait --for=condition=Initialized "pods/$ripsaw_pod" --namespace ripsaw --timeout=60s
-  kubectl wait --for=condition=Ready "pods/$ripsaw_pod" --namespace ripsaw --timeout=300s
+  kubectl wait --for=condition=Initialized "pods/$ripsaw_pod" --namespace my-ripsaw --timeout=60s
+  kubectl wait --for=condition=Ready "pods/$ripsaw_pod" --namespace my-ripsaw --timeout=300s
 }
 
 function delete_operator {
@@ -144,7 +144,7 @@ function update_operator_image {
 
 function check_log(){
   for i in {1..10}; do
-    if kubectl logs -f $1 --namespace ripsaw | grep -q $2 ; then
+    if kubectl logs -f $1 --namespace my-ripsaw | grep -q $2 ; then
       break;
     else
       sleep 10

--- a/tests/full_test_file_trigger
+++ b/tests/full_test_file_trigger
@@ -1,8 +1,11 @@
-build/
-deploy/
-group_vars/
-resources/
-tests/
+build/Dockerfile
+deploy/10_service_account.yaml
+deploy/20_role.yaml
+deploy/30_role_binding.yaml
+deploy/40_cluster_role_kubevirt.yaml
+group_vars/all.yml
+resources/operator.yaml
+tests/common.sh
 playbook.yml
 test.sh
 watches.yaml

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -16,9 +16,9 @@ function functional_test_byowl {
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   byowl_pod=$(get_pod 'app=byowl' 300)
-  kubectl -n ripsaw wait --for=condition=Initialized "pods/$byowl_pod" --timeout=200s
-  kubectl -n ripsaw  wait --for=condition=complete -l app=byowl jobs
-  kubectl -n ripsaw logs "$byowl_pod" | grep "Test"
+  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$byowl_pod" --timeout=200s
+  kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl jobs
+  kubectl -n my-ripsaw logs "$byowl_pod" | grep "Test"
   echo "BYOWL test: Success"
 }
 

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: byowl-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: byowl

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   cleanup: false
   workload:

--- a/tests/test_crs/valid_fiod_store.yaml
+++ b/tests/test_crs/valid_fiod_store.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   cleanup: false
   elasticsearch:

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: iperf3

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: pgbench-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: "pgbench"

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: smallfile

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: sysbench

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   cleanup: false
   workload:

--- a/tests/test_crs/valid_uperf_store.yaml
+++ b/tests/test_crs/valid_uperf_store.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: example-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   elasticsearch:
     server: <es_server>

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -2,7 +2,7 @@ apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: ycsb-mongo-benchmark
-  namespace: ripsaw
+  namespace: my-ripsaw
 spec:
   workload:
     name: ycsb

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -17,11 +17,11 @@ function functional_test_fio {
   kubectl apply -f tests/test_crs/valid_fiod.yaml
   pod_count 'app=fio-benchmark' 2 300
   fio_pod=$(get_pod 'app=fiod-client' 300)
-  kubectl wait --for=condition=Initialized "pods/$fio_pod" --namespace ripsaw --timeout=200s
-  kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace ripsaw --timeout=500s
+  kubectl wait --for=condition=Initialized "pods/$fio_pod" --namespace my-ripsaw --timeout=200s
+  kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=500s
   sleep 30
   # ensuring the run has actually happened
-  kubectl logs "$fio_pod" --namespace ripsaw | grep "Run status"
+  kubectl logs "$fio_pod" --namespace my-ripsaw | grep "Run status"
   echo "Fio distributed test: Success"
 }
 

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -17,11 +17,11 @@ function functional_test_iperf {
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   pod_count 'app=iperf3-bench-server' 1 300
   iperf_client_pod=$(get_pod 'app=iperf3-bench-client' 300)
-  kubectl -n ripsaw wait --for=condition=Initialized "pods/$iperf_client_pod" --timeout=200s
-  kubectl -n ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s
+  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$iperf_client_pod" --timeout=200s
+  kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s
   sleep 5
   # ensuring that iperf actually ran and we can access metrics
-  kubectl logs "$iperf_client_pod" --namespace ripsaw | grep "iperf Done."
+  kubectl logs "$iperf_client_pod" --namespace my-ripsaw | grep "iperf Done."
   echo "iperf test: Success"
 }
 

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -15,13 +15,13 @@ function functional_test_smallfile {
   apply_operator
   kubectl apply -f tests/test_crs/valid_smallfile.yaml
   sleep 15
-  smallfile_pod=$(kubectl get pods -l app=smallfile-benchmark --namespace ripsaw -o name | cut -d/ -f2 | grep client)
+  smallfile_pod=$(kubectl get pods -l app=smallfile-benchmark --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
   echo smallfile_pod $smallfile_pod
-  kubectl wait --for=condition=Initialized "pods/$smallfile_pod" --namespace ripsaw --timeout=200s
-  kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace ripsaw --timeout=100s
+  kubectl wait --for=condition=Initialized "pods/$smallfile_pod" --namespace my-ripsaw --timeout=200s
+  kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace my-ripsaw --timeout=100s
   sleep 30
   # ensuring the run has actually happened
-  kubectl logs "$smallfile_pod" --namespace ripsaw | grep "RUN STATUS"
+  kubectl logs "$smallfile_pod" --namespace my-ripsaw | grep "RUN STATUS"
   echo "Smallfile test: Success"
 }
 

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -16,12 +16,12 @@ function functional_test_sysbench {
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   sysbench_pod=$(get_pod 'app=sysbench' 300)
-  kubectl wait --for=condition=Initialized "pods/$sysbench_pod" --namespace ripsaw --timeout=200s
+  kubectl wait --for=condition=Initialized "pods/$sysbench_pod" --namespace my-ripsaw --timeout=200s
   # Higher timeout as it takes longer
-  kubectl wait --for=condition=complete -l app=sysbench --namespace ripsaw jobs
+  kubectl wait --for=condition=complete -l app=sysbench --namespace my-ripsaw jobs
   # sleep isn't needed as the sysbench is kind: job so once it's complete we can access logs
   # ensuring the run has actually happened
-  kubectl logs "$sysbench_pod" --namespace ripsaw | grep "execution time"
+  kubectl logs "$sysbench_pod" --namespace my-ripsaw | grep "execution time"
   echo "Sysbench test: Success"
 }
 

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -17,15 +17,15 @@ function functional_test_uperf {
   kubectl apply -f tests/test_crs/valid_uperf.yaml
   pod_count 'type=uperf-bench-server' 1 300
   uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  kubectl -n ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
-  kubectl -n ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
+  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
+  kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30
-  kubectl get pods -l name=benchmark-operator --namespace ripsaw -o name | cut -d/ -f2 | xargs -I{} kubectl -n ripsaw exec {} -- cat /tmp/current_run
+  kubectl get pods -l name=benchmark-operator --namespace my-ripsaw -o name | cut -d/ -f2 | xargs -I{} kubectl -n my-ripsaw exec {} -- cat /tmp/current_run
 
   # ensuring that uperf actually ran and we can access metrics
-  kubectl logs "$uperf_client_pod" --namespace ripsaw | grep Success
+  kubectl logs "$uperf_client_pod" --namespace my-ripsaw | grep Success
   echo "Uperf test: Success"
 }
 functional_test_uperf

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -17,15 +17,15 @@ function functional_test_uperf_serviceip {
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   pod_count 'type=uperf-bench-server' 1 300
   uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  kubectl wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
-  kubectl wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
+  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
+  kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30
-  kubectl get pods -l name=benchmark-operator --namespace ripsaw -o name | cut -d/ -f2 | xargs -I{} kubectl exec {} -- cat /tmp/current_run
+  kubectl get pods -l name=benchmark-operator --namespace my-ripsaw -o name | cut -d/ -f2 | xargs -I{} kubectl -n my-ripsaw exec {} -- cat /tmp/current_run
 
   # ensuring that uperf actually ran and we can access metrics
-  kubectl logs "$uperf_client_pod" --namespace ripsaw | grep Success
+  kubectl logs "$uperf_client_pod" --namespace my-ripsaw | grep Success
   echo "Uperf test: Success"
 }
 functional_test_uperf_serviceip

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -5,9 +5,9 @@ source tests/common.sh
 
 function finish {
   echo "Cleaning up ycsb"
-  kubectl delete -n ripsaw benchmark/ycsb-mongo-benchmark
-  kubectl delete -n ripsaw statefulset/mongo
-  kubectl delete -n ripsaw service/mongo
+  kubectl delete -n my-ripsaw benchmark/ycsb-mongo-benchmark
+  kubectl delete -n my-ripsaw statefulset/mongo
+  kubectl delete -n my-ripsaw service/mongo
   delete_operator
 }
 
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
  name: mongo
- namespace: ripsaw
+ namespace: my-ripsaw
  labels:
    name: mongo
 spec:
@@ -37,7 +37,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
  name: mongo
- namespace: ripsaw
+ namespace: my-ripsaw
 spec:
  serviceName: "mongo"
  replicas: 1
@@ -66,9 +66,9 @@ spec:
 EOF
   kubectl apply -f tests/test_crs/valid_ycsb-mongo.yaml
   ycsb_load_pod=$(get_pod 'name=ycsb-load' 300)
-  kubectl wait --for=condition=Initialized "pods/$ycsb_load_pod" -n ripsaw --timeout=60s
-  kubectl wait --for=condition=Complete jobs -l 'name=ycsb-load' -n ripsaw --timeout=300s
-  kubectl logs -n ripsaw $ycsb_load_pod | grep 'Starting test'
+  kubectl wait --for=condition=Initialized "pods/$ycsb_load_pod" -n my-ripsaw --timeout=60s
+  kubectl wait --for=condition=Complete jobs -l 'name=ycsb-load' -n my-ripsaw --timeout=300s
+  kubectl logs -n my-ripsaw $ycsb_load_pod | grep 'Starting test'
   echo "ycsb test: Success"
 }
 


### PR DESCRIPTION
Ripsaw can now also be installed through operatorhub.io, in which case
all the resources would be in my-ripsaw namespace. To avoid confusion, updating
all docs to refer to my-ripsaw namespace. Thus the docs/instruction would remain same
irrespective of how ripsaw is deployed.