### PR TITLE
Implement looping through a list of total number of databases

### DIFF
--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -44,10 +44,10 @@ spec:
 
       ## Ripsaw-specific options
       samples: 1
-      # TODO: test_sequential not yet implemented; all tests are currently pseudo-parallel
-      # Tests of multiple databases will be done in parallel unless
-      # test_sequential is set to True
-      #test_sequential: False
+      # num_databases_pattern takes a pattern definition, one of:
+      # 'add1' (1,2,3,...), 'add2' (2,4,6,...), 'log2' (1,2,4,8,...), or 'all'
+      # The default if left blank or undefined is 'all'
+      num_databases_pattern: 'all'
 
       ## List of databases to test
       # Note: 'databases' below is a list structures to identify multiple
@@ -63,6 +63,16 @@ spec:
           # pin_node is an optional kubernetes hostname to which the pgbench pod will be pinned
           pin_node:
 ```
+
+The `num_databases_pattern` feature allows you to ramp up the size of the test against the list of databases.
+
+The default of `all` will simply set a single list value equal to the total number of entries in the `databases` list, and so it will perform one outer-loop run against all listed databases simulaneously.
+
+The `add1` and `add2` values will create lists of total number of databases under test. For `add1`, the outer loop will test against 1 database, then 2 databases, then 3, then 4, and so on. For `add2` it will do the same with only even numbers, testing 2 databases, then 4, then 6, and so on.
+
+The `log2` value will increment through a set of values on a log2 scale up to the total number of databases in the list, thus testing 1 database, then 2, then 4, then 8, and so on.
+
+Note that the `add2` and `log2` values may not end up testing 100% of the databases listed, since `add2` will always end on an even number and `log2` will always end on the highest integer on the log2 curve up to the total number of databases (i.e., if you provide 100 databases in the list, the last `log2` test will be against 64 databases since the next log2 value would be 128)
 
 Once done creating/editing the resource file, you can run it by:
 
@@ -130,6 +140,7 @@ spec:
       cmd_flags: ''
       init_cmd_flags: ''
       samples: 3
+      num_databases_pattern: 'all'
       databases:
         - host: my.postgres.host
           user: myuser

--- a/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
@@ -40,6 +40,10 @@ spec:
       # Tests of multiple databases will be done in parallel unless
       # test_sequential is set to True
       #test_sequential: False
+      # num_databases_pattern takes a pattern definition, one of:
+      # 'add1' (1,2,3,...), 'add2' (2,4,6,...), 'log2' (1,2,4,8,...), or 'all'
+      # The default if left blank or undefined is 'all'
+      num_databases_pattern: 'all'
 
       ## List of databases to test
       # Note: 'databases' below is a list structures to identify multiple

--- a/roles/pgbench/defaults/main.yml
+++ b/roles/pgbench/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 db_port: 5432
+num_databases_pattern: "{{ pgbench.num_databases_pattern|default('all') }}"

--- a/roles/pgbench/tasks/generate_num_databases.yml
+++ b/roles/pgbench/tasks/generate_num_databases.yml
@@ -1,0 +1,24 @@
+---
+- name: Set num_databases for add1
+  set_fact:
+    num_databases: "{{ num_databases|default([]) + [(item.0|int + 1)] }}"
+  with_indexed_items: "{{ pgbench.databases }}"
+  when: num_databases_pattern == "add1"
+
+- name: Set num_databases for add2
+  set_fact:
+    num_databases: "{{ num_databases|default([]) + [(item.0|int + 1)] }}"
+  with_indexed_items: "{{ pgbench.databases }}"
+  when: num_databases_pattern == "add2" and item.0|int is odd
+
+- name: Set num_databases for log2
+  set_fact:
+    num_databases: "{{ num_databases|default([]) + [(item.0|int + 1)] }}"
+  with_indexed_items: "{{ pgbench.databases }}"
+  when: num_databases_pattern == "log2" and (((item.0|int + 1)|log(2)) is even or ((item.0|int + 1)|log(2)) is odd)
+
+- name: Set num_databases for all
+  set_fact:
+    num_databases: "{{ num_databases|default([]) + [pgbench.databases|length] }}"
+  when: num_databases_pattern == "all"
+

--- a/roles/pgbench/tasks/main.yml
+++ b/roles/pgbench/tasks/main.yml
@@ -8,27 +8,14 @@
       - name = benchmark-operator
   register: bo
 
-- name: Init workload start signal to false
-  command: "redis-cli set pgb_start false;"
+- name: Generate list of database counts
+  include_tasks: generate_num_databases.yml
 
-- name: Init client ready state to empty
-  command: "redis-cli del pgb_client_ready"
-
-- name: Setup pgbench test job(s)
-  k8s:
-    definition: "{{ lookup('template', 'templates/workload.yml.j2') }}"
-  with_indexed_items: "{{ pgbench.databases }}"
-
-- name: Wait for all clients to be ready
-  shell: "redis-cli --raw llen pgb_client_ready"
-  register: client_ready
-  until: "client_ready.stdout|int == pgbench.databases|length"
-  # timeout in minutes times 6 times delay of 10 seconds equals timeout in seconds
-  retries: "{{ pgbench.timeout|int * 6 }}"
-  delay: 10
-
-- name: Signal workloads to start
-  command: "redis-cli set pgb_start true"
+- name: Begin pgbench workloads
+  include_tasks: run_workload.yml
+  with_items: "{{ num_databases }}"
+  loop_control:
+    loop_var: dbnum
 
 #TODO:
 #- database passwords are currently provided in plain text in the CR

--- a/roles/pgbench/tasks/run_workload.yml
+++ b/roles/pgbench/tasks/run_workload.yml
@@ -1,0 +1,35 @@
+---
+- name: Init workload start signal to false
+  command: "redis-cli set pgb_start false;"
+
+- name: Init client ready state to empty
+  command: "redis-cli del pgb_client_ready"
+
+- name: Setup pgbench test job(s)
+  k8s:
+    definition: "{{ lookup('template', 'templates/workload.yml.j2') }}"
+  with_indexed_items: "{{ pgbench.databases }}"
+  when: item.0|int in range(dbnum)
+
+- name: Wait for all clients to be ready
+  shell: "redis-cli --raw llen pgb_client_ready"
+  register: client_ready
+  until: client_ready.stdout|int == dbnum|int
+  # timeout in minutes times 6 times delay of 10 seconds equals timeout in seconds
+  retries: "{{ pgbench.timeout|int * 6 }}"
+  delay: 10
+
+- name: Signal workloads to start
+  command: "redis-cli set pgb_start true"
+
+- name: Wait for pods to complete
+  k8s_facts:
+    kind: pod
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - app = pgbench-client
+  register: pgbench_pods
+  until: "'Succeeded' in (pgbench_pods | json_query('resources[].status.phase'))"
+  retries: "{{ pgbench.timeout|int * 6 }}"
+  delay: 10

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -2,7 +2,7 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
-  name: '{{ meta.name }}-pgbench-client-{{ item.0|int + 1 }}'
+  name: '{{ meta.name }}-pgbench-{{ dbnum }}-dbs-client-{{ item.0|int + 1 }}'
   namespace: '{{ operator_namespace }}'
 spec:
   ttlSecondsAfterFinished: 600

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -17,6 +17,7 @@ spec:
       init_cmd_flags: ''
       scaling_factor: 1
       samples: 2
+      num_databases_pattern: 'all'
       databases:
         - host:
           user: ci


### PR DESCRIPTION
based on a pattern supplied in the CR file

This allows us an outer loop that will ramp up the number of databases we are testing against based on a pattern option supplied in the CR file.