### PR TITLE
correct example CR file for changes in PR #154

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -11,13 +11,17 @@ spec:
       servers: 1
       pin: false
       pin_server: "master-0"
-      job: seq
-      jobname: seq
-      bs: 64k
+      jobs:
+        - read
+        - write
+      bs:
+        - 64k
+      numjobs:
+        - 1
       iodepth: 4
       runtime: 60
       ramp_time: 5
-      filesize: 2
+      filesize: 2g
       log_sample_rate: 1000
       #storageclass: rook-ceph-block
       #storagesize: 5Gi

--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -23,7 +23,7 @@ data:
 
     [{{job}}]
     rw={{job}}
-    size={{fiod.filesize}}g
+    size={{fiod.filesize}}
     write_bw_log=fio
     write_iops_log=fio
     write_lat_log=fio

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -22,5 +22,5 @@ spec:
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1
+      filesize: 1g
       log_sample_rate: 1000

--- a/tests/test_crs/valid_fiod_store.yaml
+++ b/tests/test_crs/valid_fiod_store.yaml
@@ -27,5 +27,5 @@ spec:
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1
+      filesize: 1g
       log_sample_rate: 1000


### PR DESCRIPTION
Corrects the CR file to work with the changes from PR #154. Also makes a slight change to the CR and the configmap so that the `filesize` scale unit is passed in the CR instead of coded into the configmap.