### PR TITLE
improve fio jobfile and allow for more customization in the CR

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -19,36 +19,53 @@ spec:
   workload:
     name: "fio_distributed"
     args:
+      samples: 1
+      servers: 1
       pin: false
-      samples: 2
-      servers: 2
       pin_server: "master-0"
       jobs: #the list can take any of the values in [write,trim,randread,randwrite.randtrim,rw/readwrite,randrw,trimwrite]
         - read
         - write
       bs:
-        - 64k
+        - 64Ki
       numjobs:
         - 1
       iodepth: 4
-      runtime: 3
-      ramp_time: 1
-      filesize: 1
+      runtime: 60
+      ramp_time: 5
+      filesize: 2Gi
       log_sample_rate: 1000
       storageclass: rook-ceph-block
       storagesize: 5Gi
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#    - "key=value"
+  job_params:
+    - jobname_match: "w"
+      params:
+        - "fsync_on_close=1"
+        - "create_on_open=1"
+    - jobname_match: "rw"
+      params:
+        - "rwmixread=50"
+    - jobname_match: "readwrite"
+      params:
+        - "rwmixread=50"
+#    - jobname_match: "<search_string>"
+#      params:
+#        - "key=value"
 ```
-Ripsaw will run the jobs sequentially.
+Ripsaw will run the provided `jobs` sequentially.
 
-To disable the need for PVs, simply comment out the `storageclass` key.
+To disable the need for PVs, simply comment out or exclude the `storageclass` key.
 
 `pin` and `pin_server` will allow the benchmark runner pick what specific node to run FIO on.
 
-Additionally, fio distributed will default to numjobs:1, and this current cannot be overwritten.
-
 (*Technical Note*: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.)
 
-## Indexing in elasticsearch and visualization through Grafana ( Experimental )
+## Indexing in elasticsearch and visualization through Grafana
 
 ### Setup of Elasticsearch and Grafana
 
@@ -61,18 +78,11 @@ Currently, we have tested with elasticsearch 7.0.1, so please deploy an elastics
 There are are many guides that are quite helpful to deploy elasticsearch, for starters
 you can follow the guide to deploy with docker by [elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/docker.html).
 
-Please note that the <es_index> being referred to here is the es_index you provide in the cr. You'd probably want to call it `fio`.
-But we've provided freedom for you to call it something else, which can be helpful if you already have indices starting with `fio`.
+Once you have verified that you can access the elasticsearch, you'll have to create an index template for ripsaw-fio-logs.
 
-Ripsaw will be indexing fio logs to the index `<es_index>-logs` so if es_index is fio, then the index is `<es_index>-logs`.
+We send fio logs to the index `ripsaw-fio-logs`, the template can be found in [arsenal](https://github.com/cloud-bulldozer/arsenal/blob/master/fio-distributed/elasticsearch/7.0.1/fio-logs.json).
 
-Ripsaw will be indexing fio result json to the index `<es_index>-result` so if es_index is fio, then the index is `fio-result`.
-
-Once you have verified that you can access the elasticsearch, you'll have to create an index template for fio-logs.
-We send fio logs to the index `<es_index>-logs`, the template can be found in [arsenal](https://github.com/cloud-bulldozer/arsenal/blob/master/fio-distributed/elasticsearch/7.0.1/fio-logs.json).
-Please replace `<es_index>` in the template with your desired name.
-
-For fio json files, no template is required. However if you're an advanced user of elasticsearch, you can create it and edit its settings.
+Ripsaw will be indexing the fio result json to the index `ripsaw-fio-result`. For this, no template is required. However if you're an advanced user of elasticsearch, you can create it and edit its settings.
 
 
 #### Grafana
@@ -84,45 +94,66 @@ Once you've set it up, you can import the dashboard from the template in [arsena
 
 You can then follow instructions to import dashboard like adding the data source following the [grafana docs](https://grafana.com/docs/reference/export_import/#importing-a-dashboard)
 
-Please set the data source to point to the earlier, and the index name should be `<es_index>-logs` given in CR.
+Please set the data source to point to the earlier, and the index name should be `ripsaw-fio-logs`.
 The field for timestamp will always be `time_ms` .
 
 ### Changes to CR for indexing/visualization
 
 If you'd like to try to experiment with storing results in a pv and have followed
-instructions to deploy operator with attached pvc and would like to send results to ES(elasticsearch).
+instructions to deploy operator with attached pvc and would like to send results to ES (elasticsearch).
 you can instead define a custom resource as follows:
 
 ```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: fio-benchmark
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: <es_host>
-    port: <es_port>
-    index: <es_index>
-  test_user: rht_perf_ci # test_user is just a key that points to user triggering ripsaw, useful to search results in ES
+    server: my.elasticsearch.server
+    port: 9200
+  test_user: ripsaw
   workload:
     name: "fio_distributed"
     args:
+      samples: 1
+      servers: 1
       pin: false
-      samples: 2
-      servers: 2
       pin_server: "master-0"
       jobs: #the list can take any of the values in [write,trim,randread,randwrite.randtrim,rw/readwrite,randrw,trimwrite]
         - read
         - write
       bs:
-        - 64k
+        - 64Ki
       numjobs:
         - 1
       iodepth: 4
-      runtime: 3
-      ramp_time: 1
-      filesize: 1
+      runtime: 60
+      ramp_time: 5
+      filesize: 2Gi
       log_sample_rate: 1000
-      log_sample_rate: 1000 # provide only if job is seq or rand
+      storageclass: rook-ceph-block
+      storagesize: 5Gi
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#    - "key=value"
+  job_params:
+    - jobname_match: "w"
+      params:
+        - "fsync_on_close=1"
+        - "create_on_open=1"
+    - jobname_match: "rw"
+      params:
+        - "rwmixread=50"
+    - jobname_match: "readwrite"
+      params:
+        - "rwmixread=50"
+#    - jobname_match: "<search_string>"
+#      params:
+#        - "key=value"
 ```
+
+> Note: The `test_user` value is arbitrary metadata for your indexing needs, and if left undefined it will default to `ripsaw`.

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -1,9 +1,13 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: fio-benchmark
   namespace: my-ripsaw
 spec:
+#  elasticsearch:
+#    server: <es_server>
+#    port: 9200
+#  test_user: ripsaw
   workload:
     name: "fio_distributed"
     args:
@@ -15,13 +19,32 @@ spec:
         - read
         - write
       bs:
-        - 64k
+        - 64Ki
       numjobs:
         - 1
       iodepth: 4
       runtime: 60
       ramp_time: 5
-      filesize: 2g
+      filesize: 2Gi
       log_sample_rate: 1000
       #storageclass: rook-ceph-block
       #storagesize: 5Gi
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#    - "key=value"
+  job_params:
+    - jobname_match: "w"
+      params:
+        - "fsync_on_close=1"
+        - "create_on_open=1"
+    - jobname_match: "rw"
+      params:
+        - "rwmixread=50"
+    - jobname_match: "readwrite"
+      params:
+        - "rwmixread=50"
+#    - jobname_match: "<search_string>"
+#      params:
+#        - "key=value"

--- a/roles/fio-distributed/defaults/main.yml
+++ b/roles/fio-distributed/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+es: "{{ elasticsearch|default([]) }}"
+es_server: "{{ es.server|default('') }}"
+es_port: "{{ es.port|default(9200) }}"
+es_index: "ripsaw-fio"
+test_user: "ripsaw"

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -14,20 +14,23 @@ spec:
       containers:
       - name: fio-client
         image: "quay.io/cloud-bulldozer/fio:latest"
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user }}"
+{% if es_server %}
+          - name: es
+            value: "{{ es_server }}"
+          - name: es_port
+            value: "{{ es_port }}"
+          - name: es_index
+            value: "{{ es_index }}"
+{% endif %}
         command: ["/bin/sh", "-c"]
         args:
           - "cat /tmp/host/hosts;
-             export uuid={{uuid}};
-{% if elasticsearch is defined %}
-{% if elasticsearch.server is defined %}
-             export es={{elasticsearch.server}};
-             export es_port={{elasticsearch.port}};
-             export es_index={{elasticsearch.index}}
-{% endif %}
-{% endif %}
-{% if test_user is defined %}
-             export test_user={{test_user}};
-{% endif %}
              for file in $(ls /tmp/fio/ | egrep ^fiojob); do
                cat /tmp/fio/$file;
                for i in `seq 1 {{fiod.samples}}`; do

--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -7,35 +7,46 @@ metadata:
 data:
 {% for job in fiod.jobs %}
 {% for bs in fiod.bs %}
-{% for numjob in fiod.numjobs %}
-  fiojob-{{job}}-{{bs}}-{{numjob}}: |
+{% for numjobs in fiod.numjobs %}
+  fiojob-{{job}}-{{bs}}-{{numjobs}}: |
     [global]
     directory={{fio_path}}
-    ioengine=libaio
-    bs={{bs}}
-    iodepth={{fiod.iodepth}}
-    direct=1
-    create_on_open=1
-    time_based=1
-    runtime={{fiod.runtime}}
-    clocksource=clock_gettime
-    ramp_time={{fiod.ramp_time}}
-
-    [{{job}}]
-    rw={{job}}
-    size={{fiod.filesize}}
+    filename_format=f.\$jobnum.\$filenum
     write_bw_log=fio
     write_iops_log=fio
     write_lat_log=fio
     write_hist_log=fio
-    numjobs={{numjob}}
-{% if 'w' in job %}
-    end_fsync=1
-{% endif %}
-    per_job_logs=1
     log_avg_msec={{fiod.log_sample_rate}}
     log_hist_msec={{fiod.log_sample_rate}}
-    filename_format=f.\$jobnum.\$filenum
+    clocksource=clock_gettime
+    kb_base=1000
+    unit_base='8'
+    ioengine=libaio
+    size={{fiod.filesize}}
+    bs={{bs}}
+    iodepth={{fiod.iodepth}}
+    direct=1
+    time_based=1
+    runtime={{fiod.runtime}}
+    ramp_time={{fiod.ramp_time}}
+    numjobs={{numjobs}}
+
+    [{{job}}]
+    rw={{job}}
+{% if global_overrides|default([])|length %}
+{% for override in global_overrides %}
+    {{ override }}
+{% endfor %}
+{% endif %}
+{% if job_params|default([])|length %}
+{% for match in job_params %}
+{% if match.jobname_match in job %}
+{% for param in match.params %}
+    {{ param }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -16,11 +16,30 @@ spec:
         - read
         - write
       bs:
-        - 64k
+        - 64Ki
       numjobs:
         - 1
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1g
+      filesize: 1Gi
       log_sample_rate: 1000
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#    - "key=value"
+  job_params:
+    - jobname_match: "w"
+      params:
+        - "fsync_on_close=1"
+        - "create_on_open=1"
+    - jobname_match: "rw"
+      params:
+        - "rwmixread=50"
+    - jobname_match: "readwrite"
+      params:
+        - "rwmixread=50"
+#    - jobname_match: "<search_string>"
+#      params:
+#        - "key=value"

--- a/tests/test_crs/valid_fiod_store.yaml
+++ b/tests/test_crs/valid_fiod_store.yaml
@@ -1,14 +1,13 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: fio-benchmark
   namespace: my-ripsaw
 spec:
   cleanup: false
   elasticsearch:
     server: <es_server>
     port: 9200
-    index: fio
   test_user: rht_perf_ci
   workload:
     name: "fio_distributed"
@@ -21,11 +20,30 @@ spec:
         - read
         - write
       bs:
-        - 64k
+        - 64Ki
       numjobs:
         - 1
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1g
+      filesize: 1Gi
       log_sample_rate: 1000
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#    - "key=value"
+  job_params:
+    - jobname_match: "w"
+      params:
+        - "fsync_on_close=1"
+        - "create_on_open=1"
+    - jobname_match: "rw"
+      params:
+        - "rwmixread=50"
+    - jobname_match: "readwrite"
+      params:
+        - "rwmixread=50"
+#    - jobname_match: "<search_string>"
+#      params:
+#        - "key=value"

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -21,7 +21,7 @@ function functional_test_fio {
   kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=500s
   sleep 30
   # ensuring the run has actually happened
-  kubectl logs "$fio_pod" --namespace my-ripsaw | grep "succesfully finished executing for jobname"
+  kubectl logs "$fio_pod" --namespace my-ripsaw | grep "successfully finished executing for jobname"
   echo "Fio distributed test: Success"
 }
 


### PR DESCRIPTION
There are several things going on in this commit:

1. The `elasticsearch` and `test_user` keys in the CR now have default values. This means that `elasticsearch.port`, `elasticsearch.index`, and `test_user` can all be left undefined or blank, and they will default to `9200`, `ripsaw-fio`, and `ripsaw`, respectively. The `elasticsearch.server` key can be left blank or undefined, and it will default to `''`, which will fail the jinja2 test in the template and skip adding the es environment vars.
2. Environment vars in the client template are now set in a k8s-native way, and the jinja2 logic surrounding the es stuff is simplified.
3. When defining the `storagesize` in the CR, you currently need to use IEC prefixes for base-2 values (KiB, MiB, etc). To make the values for fio consistent with this, the fio jobfile now sets `kb_base=1000`, which means that K or KB will be interpreted as base-10, while Ki or KiB will be base-2, consistent with the IEC standards. The CR examples have been updated to use IEC notation accordingly.
4. All fio jobfile defaults in the configmap have been moved to the `[global]` section. This assists with the implementation of item 5 below.
5. An "expert" section has been added to the CR files. This allows for fine user customization of the jobs, both by introducing overrides to the `[global]` values, which will be inserted at the `[job]` level, as well as per-job parameter insertions based on string matches.
6. Some general default jobfile changes:
 a. Introduced `unit_base='8'` to ensure all data is consistently reported as bytes instead of auto-adjusted between bits and bytes. (note a quirk/bug that the value here has to be quoted as '8' or the fio job will fail)
 b. Changed from `end_fsync=1` to `fsync_on_close=1` for write jobs (now defined in the CR expert section)
 c. Changed `create_on_open=1` to only apply to write jobs (now defined in the CR expert section; it is important that we don't use this parameter for read jobs)
7. Set `imagePullPolicy: Always` for the client container

There are a couple of other cosmetic changes not worth listing.