### PR TITLE
Allow for number of workers to be increased

### DIFF
--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -32,6 +32,9 @@ spec:
               value: "4"
             - name: OPERATOR_NAME
               value: "benchmark-operator"
+            - name: WORKER_BENCHMARK_RIPSAW_CLOUDBULLDOZER_IO
+              value: "1"
+
         - name: redis-master
           image: k8s.gcr.io/redis:v1
           env:


### PR DESCRIPTION
Facilitating increasing of the number of CRs we can run together, currently defaulting to one, but after work to the roles to update labels for resources to include uuid, this can be increased to 2.