### PR TITLE
Collect and display more detail for CI Issue #71

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -151,3 +151,26 @@ function check_log(){
     fi
   done
 }
+
+# Takes 2 or more arguments: 'command to run', 'time to wait until true' 
+# Any additional arguments will be passed to kubectl -n my-ripsaw logs to provide logging if a timeout occurs
+function wait_for() {
+  if ! timeout -k $2 $2 $1
+  then
+      echo "Timeout exceeded for: "$1
+
+      #Always provide the benchmark-operator logs
+      echo "Benchmark-operator logs:"
+      kubectl -n my-ripsaw logs --tail=40 -l name=benchmark-operator -c benchmark-operator
+
+      counter=3
+      until [ $counter -gt $# ]
+      do
+        echo "Logs from "${@:$counter}
+        kubectl -n my-ripsaw logs --tail=40 ${@:$counter}
+        counter=$(( counter+1 ))
+      done
+      return 1
+  fi
+  return 0
+}

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -16,8 +16,8 @@ function functional_test_byowl {
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   byowl_pod=$(get_pod 'app=byowl' 300)
-  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$byowl_pod" --timeout=200s
-  kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl jobs
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=200s" "200s" $byowl_pod
+  wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl jobs --timeout=300s" "300s" $byowl_pod
   kubectl -n my-ripsaw logs "$byowl_pod" | grep "Test"
   echo "BYOWL test: Success"
 }

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -17,8 +17,8 @@ function functional_test_fio {
   kubectl apply -f tests/test_crs/valid_fiod.yaml
   pod_count 'app=fio-benchmark' 2 300
   fio_pod=$(get_pod 'app=fiod-client' 300)
-  kubectl wait --for=condition=Initialized "pods/$fio_pod" --namespace my-ripsaw --timeout=200s
-  kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=500s
+  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod --namespace my-ripsaw --timeout=200s" "200s" $fio_pod
+  wait_for "kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=500s" "500s" $fio_pod
   sleep 30
   # ensuring the run has actually happened
   kubectl logs "$fio_pod" --namespace my-ripsaw | grep "successfully finished executing for jobname"

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -17,8 +17,8 @@ function functional_test_iperf {
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   pod_count 'app=iperf3-bench-server' 1 300
   iperf_client_pod=$(get_pod 'app=iperf3-bench-client' 300)
-  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$iperf_client_pod" --timeout=200s
-  kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=200s" "200s" $iperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s" "100s" $iperf_client_pod
   sleep 5
   # ensuring that iperf actually ran and we can access metrics
   kubectl logs "$iperf_client_pod" --namespace my-ripsaw | grep "iperf Done."

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -67,9 +67,9 @@ EOF
   # deploy the test CR with the postgres pod IP
   sed s/host:/host:\ ${postgres_ip}/ tests/test_crs/valid_pgbench.yaml | kubectl apply -f -
   pgbench_pod=$(get_pod 'app=pgbench-client' 300)
-  kubectl wait --for=condition=Initialized "pods/$pgbench_pod" -n my-ripsaw --timeout=60s
-  kubectl wait --for=condition=Ready "pods/$pgbench_pod" -n my-ripsaw --timeout=60s
-  kubectl wait --for=condition=Complete jobs -l 'app=pgbench-client' -n my-ripsaw --timeout=300s
+  wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
+  wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
+  wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client -n my-ripsaw --timeout=300s" "300s" $pgbench_pod
   kubectl logs -n my-ripsaw $pgbench_pod | grep 'tps ='
   echo "pgbench test: Success"
 }

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -18,8 +18,8 @@ function functional_test_smallfile {
   sleep 15
   smallfile_pod=$(kubectl get pods -l app=smallfile-benchmark --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
   echo smallfile_pod $smallfile_pod
-  kubectl wait --for=condition=Initialized "pods/$smallfile_pod" --namespace my-ripsaw --timeout=200s
-  kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace my-ripsaw --timeout=100s
+  wait_for "kubectl wait --for=condition=Initialized pods/$smallfile_pod --namespace my-ripsaw --timeout=200s" "200s" $smallfile_pod
+  wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace my-ripsaw --timeout=100s" "100s" $smallfile_pod
   sleep 30
   # ensuring the run has actually happened
   kubectl logs "$smallfile_pod" --namespace my-ripsaw | grep "RUN STATUS"

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -16,9 +16,9 @@ function functional_test_sysbench {
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   sysbench_pod=$(get_pod 'app=sysbench' 300)
-  kubectl wait --for=condition=Initialized "pods/$sysbench_pod" --namespace my-ripsaw --timeout=200s
+  wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=200s" "200s" $sysbench_pod
   # Higher timeout as it takes longer
-  kubectl wait --for=condition=complete -l app=sysbench --namespace my-ripsaw jobs
+  wait_for "kubectl wait --for=condition=complete -l app=sysbench --namespace my-ripsaw jobs" "300s" $sysbench_pod
   # sleep isn't needed as the sysbench is kind: job so once it's complete we can access logs
   # ensuring the run has actually happened
   kubectl logs "$sysbench_pod" --namespace my-ripsaw | grep "execution time"

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -17,8 +17,8 @@ function functional_test_uperf {
   kubectl apply -f tests/test_crs/valid_uperf.yaml
   pod_count 'type=uperf-bench-server' 1 300
   uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
-  kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=500s
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=500s" "500s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -17,8 +17,8 @@ function functional_test_uperf_serviceip {
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   pod_count 'type=uperf-bench-server' 1 300
   uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  kubectl -n my-ripsaw wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
-  kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s" "300s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -59,8 +59,8 @@ spec:
 EOF
   kubectl apply -f tests/test_crs/valid_ycsb-mongo.yaml
   ycsb_load_pod=$(get_pod 'name=ycsb-load' 300)
-  kubectl wait --for=condition=Initialized "pods/$ycsb_load_pod" -n my-ripsaw --timeout=60s
-  kubectl wait --for=condition=Complete jobs -l 'name=ycsb-load' -n my-ripsaw --timeout=300s
+  wait_for "kubectl wait --for=condition=Initialized pods/$ycsb_load_pod -n my-ripsaw --timeout=60s" "60s" $ycsb_load_pod
+  wait_for "kubectl wait --for=condition=Complete jobs -l name=ycsb-load -n my-ripsaw --timeout=300s" "300s" $ycsb_load_pod
   kubectl logs -n my-ripsaw $ycsb_load_pod | grep 'Starting test'
   echo "ycsb test: Success"
 }


### PR DESCRIPTION
Many of the issues we see in ci is during kubectl --wait functions. I have added a wait_for function which will dump the last 40 (arbitrary number open to adjustment) lines of the benchmark-operator logs as well as any additional pods you provide to the function.

I updated the existing test_*.sh files to use wait_for however adjustment may be desired for any additional pod logs that may want to be shown.

Additionally, I added a completion timeout of 300s for byowl and sysbench since one was not set previously.