### PR TITLE
Enable figlet usage for ease of readability during CI testing

### DIFF
--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_byowl {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   byowl_pod=$(get_pod 'app=byowl' 300)

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_fio {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_fiod.yaml
   pod_count 'app=fio-benchmark' 2 300

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_iperf {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   pod_count 'app=iperf3-bench-server' 1 300

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -15,7 +15,7 @@ trap finish EXIT
 
 # Note we don't test persistent storage here
 function functional_test_pgbench {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   # stand up postgres deployment
 cat << EOF | kubectl apply -f -

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -12,6 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_smallfile {
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_smallfile.yaml
   sleep 15

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_sysbench {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   sysbench_pod=$(get_pod 'app=sysbench' 300)

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_uperf {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf.yaml
   pod_count 'type=uperf-bench-server' 1 300

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -12,7 +12,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_uperf_serviceip {
-  #figlet $(basename $0)
+  figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   pod_count 'type=uperf-bench-server' 1 300

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -14,6 +14,7 @@ function finish {
 trap finish EXIT
 
 function functional_test_ycsb {
+  figlet $(basename $0)
   apply_operator
   # stand up mongo deployment
 cat << EOF | kubectl apply -f -


### PR DESCRIPTION
To aid in readability during CI testing I have enabled the usage of figlet in the test_*.sh scripts and installed the package on the CI systems. @dustinblack ++ for the initial setup

Resolves issue #126