### PR TITLE
Pgbench timeout

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
@@ -35,8 +35,6 @@ spec:
 
       ## Ripsaw-specific options
       samples: 1
-      # Timeout in minutes to wait for client pods to be ready
-      timeout: 5
       # TODO: test_sequential not yet implemented; all tests are currently parallel
       # Tests of multiple databases will be done in parallel unless
       # test_sequential is set to True

--- a/roles/pgbench/defaults/main.yml
+++ b/roles/pgbench/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 db_port: 5432
+pgb_base_image: "quay.io/cloud-bulldozer/pgbench"
+pgb_version: "latest"
+timeout_min: 300
 num_databases_pattern: "{{ pgbench.num_databases_pattern|default('all') }}"
 run_time: "{{ pgbench.run_time|default('') }}"
 cmd_flags: "{{ pgbench.cmd_flags|default('') }}"

--- a/roles/pgbench/tasks/calculate_timeouts.yml
+++ b/roles/pgbench/tasks/calculate_timeouts.yml
@@ -1,0 +1,42 @@
+---
+- name: Tune load_timeout for scaling factor
+  set_fact:
+    load_timeout: "{{ pgbench.scaling_factor|int * 3 }}"
+
+- name: Tune load_timeout for number of databases
+  set_fact:
+    load_timeout: "{{ load_timeout|int + (dbnum * 30) }}"
+
+- name: Ensure minimum load_timeout
+  set_fact:
+    load_timeout: "{{ timeout_min|int }}"
+  when: load_timeout|int < timeout_min|int
+
+- debug:
+    msg: "Load timeout set to {{ load_timeout }} seconds"
+
+- name: Tune run_timeout for transactions
+  set_fact:
+    run_timeout: "{{ pgbench.transactions|int * 0.005 }}"
+  when: pgbench.transactions|default(0)|int > 0
+
+- name: Tune run_timeout for run_time
+  set_fact:
+    run_timeout: "{{ pgbench.run_time|int }}"
+  when: pgbench.run_time|default(0)|int > 0
+
+- name: Tune run_timeout for clients and samples
+  set_fact:
+    run_timeout: "{{ run_timeout|int * pgbench.clients|length|int * pgbench.samples|int }}"
+
+- name: Tune run_timeout for number of databases
+  set_fact:
+    run_timeout: "{{ run_timeout|int + (dbnum * 30) }}"
+
+- name: Ensure minimum run_timeout
+  set_fact:
+    run_timeout: "{{ timeout_min|int }}"
+  when: run_timeout|int < timeout_min|int
+
+- debug:
+    msg: "Run timeout set to {{ run_timeout }} seconds"

--- a/roles/pgbench/tasks/run_workload.yml
+++ b/roles/pgbench/tasks/run_workload.yml
@@ -5,6 +5,46 @@
 - name: Init client ready state to empty
   command: "redis-cli del pgb_client_ready"
 
+- name: Calculate timeouts
+  include_tasks: calculate_timeouts.yml
+
+- name: Pre-pull pgbench container image
+  k8s:
+    definition:
+      kind: Job
+      apiVersion: batch/v1
+      metadata:
+        name: pgb-image-load-{{ item.0 }}
+        namespace: "{{ operator_namespace }}"
+        labels:
+          app: pgb-image-load
+      spec:
+        template:
+          spec:
+            containers:
+              - name: pgb-image-load-{{ item.0 }}
+                image: "{{ pgb_base_image }}:{{ pgb_version }}"
+                command: ['/bin/true']
+            restartPolicy: Never
+        backoffLimit: 4
+  retries: 6
+  delay: 10
+  with_indexed_items: "{{ pgbench.databases }}"
+
+- name: Wait for pre-pull jobs to succeed
+  k8s_facts:
+    kind: Job
+    api_version: batch/v1
+    namespace: "{{ operator_namespace }}"
+    name: pgb-image-load-{{ item.0 }}
+    #label_selectors:
+    #  - app = pgb-image-load
+  register: pgb_image_load
+  until: "pgb_image_load | json_query('resources[].status.succeeded')"
+  retries: 300
+  delay: 2
+  with_indexed_items: "{{ pgbench.databases }}"
+
 - name: Setup pgbench test job(s)
   k8s:
     definition: "{{ lookup('template', 'templates/workload.yml.j2') }}"
@@ -15,8 +55,7 @@
   shell: "redis-cli --raw llen pgb_client_ready"
   register: client_ready
   until: client_ready.stdout|int == dbnum|int
-  # timeout in minutes times 6 times delay of 10 seconds equals timeout in seconds
-  retries: "{{ pgbench.timeout|int * 6 }}"
+  retries: "{{ (load_timeout|int / 10)|int }}"
   delay: 10
 
 - name: Signal workloads to start
@@ -31,5 +70,5 @@
       - app = pgbench-client
   register: pgbench_pods
   until: "'Succeeded' in (pgbench_pods | json_query('resources[].status.phase'))"
-  retries: "{{ pgbench.timeout|int * 6 }}"
+  retries: "{{ (run_timeout|int / 10)|int }}"
   delay: 10

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: benchmark
-        image: "quay.io/cloud-bulldozer/pgbench:latest"
+        image: "{{ pgb_base_image }}:{{ pgb_version }}"
         env:
           - name: PGPASSWORD
             value: '{{ item.1.password }}'


### PR DESCRIPTION
Note: This includes the commits for #166 and so is intended to be merged behind that one.

The changes here get rid of the user-supplied timeout in the CR and instead use a series of simple calculations to dynamically determine appropriate timeouts for the load and run phases based on the scale and loop iterations of the test.