### PR TITLE
Pgbench timestamps

### DIFF
--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -39,7 +39,8 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-          - "echo 'Init Database {{ item.1.host }}/{{ item.1.db_name }}';
+          - "export run_start_timestamp=$(date +%s.%3N);
+             echo 'Init Database {{ item.1.host }}/{{ item.1.db_name }}';
              pgbench $pgbench_auth -i -s {{ pgbench.scaling_factor }} {{ init_cmd_flags }} {{ item.1.db_name }};
              if [ $? -eq 0 ]; then
                echo 'Waiting for start signal...';
@@ -49,9 +50,11 @@ spec:
                    echo 'GO!';
                  {% for clients in pgbench.clients %}
                    export database='{{ item.1.host }}/{{ item.1.db_name }}';
+                   export description='scaling factor: {{ pgbench.scaling_factor }} | threads: {{ pgbench.threads }} | clients: {{ clients }}'
                    echo '';
                    echo 'Running PGBench with {{ clients }} clients on database {{ item.1.host }}/{{ item.1.db_name }}';
                    for i in `seq 1 {{ pgbench.samples|int }}`; do
+                     export sample_start_timestamp=$(date +%s.%3N);
                      echo \"Begin test sample $i of {{ pgbench.samples }}...\";
                      export pgbench_opts=\"$pgbench_auth -c {{ clients }} -j {{ pgbench.threads }} {% if pgbench.transactions is defined and pgbench.transactions|int > 0 %} -t {{ pgbench.transactions }} {% elif run_time|int > 0 %} -T {{ run_time }} {% endif %} -s {{ pgbench.scaling_factor }} {{ cmd_flags }} {{ item.1.db_name }}\";
                      python /opt/snafu/pgbench-wrapper/pgbench-wrapper.py -r $i;


### PR DESCRIPTION
Note: This includes the commits for #166 and so is intended to be merged behind that one.

This change introduces additional timestamps for the start times of the job and of the sample. Existing timestamps record the end-time of the sample and the intermediate times for throughput/latency checks. Adding these additional timestamps to the index allows for better annotations in the visualizations, as can be seen in this sample data: 

http://marquez.perf.lab.eng.rdu2.redhat.com:3000/d/AIpX4_HZz/pgbench-dashboard?orgId=1&from=1564757895580&to=1564763492228&var-uuid=All&var-user=All