### PR TITLE
defaulting image pull policy to always

### DIFF
--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: fio-server
         image: "quay.io/cloud-bulldozer/fio:latest"
+        imagePullPolicy: Always
         ports:
           - containerPort: 8765
         command: ["/bin/sh", "-c"]

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
+        imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
           - "iperf3 -c {{ item.status.podIP }} -p {{ iperf3.port }} --{{ iperf3.transmit_type }} {{ iperf3.transmit_value }} -l {{ iperf3.length_buffer }} -P {{ iperf3.streams }} -w {{ iperf3.window_size }} -M {{ iperf3.mss }} -S {{ iperf3.ip_tos }} -O {{ iperf3.omit_start }} {{ iperf3.extra_options_client }}"

--- a/roles/load-ycsb/tasks/main.yml
+++ b/roles/load-ycsb/tasks/main.yml
@@ -26,6 +26,7 @@
             containers:
             - name: ycsb
               image: "quay.io/cloud-bulldozer/ycsb-server:latest"
+              imagePullPolicy: Always
               env:
               - name: clustername
                 value: "{{ clustername }}"

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -36,6 +36,7 @@ spec:
           - name: es_index_prefix
             value: '{{ es_index_prefix }}'
 {% endif %}
+        imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
           - "echo 'Init Database {{ item.1.host }}/{{ item.1.db_name }}';

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -14,6 +14,7 @@ spec:
       containers:
         - name: benchmark-server
           image: "quay.io/cloud-bulldozer/smallfile:master"
+          imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /root/smallfile-master/
           args:

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -17,6 +17,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["/tmp/sysbenchScript"]
         image: "quay.io/cloud-bulldozer/sysbench:latest"
+        imagePullPolicy: Always
         volumeMounts:
         - name: sysbench-volume
           mountPath: "/tmp/"

--- a/roles/ycsb-bench/tasks/main.yml
+++ b/roles/ycsb-bench/tasks/main.yml
@@ -26,6 +26,7 @@
             containers:
             - name: ycsb
               image: "quay.io/cloud-bulldozer/ycsb-server:latest"
+              imagePullPolicy: Always
               env:
               - name: clustername
                 value: "{{ clustername }}"


### PR DESCRIPTION
Although this will increase the time to run the CI test as it'll always pull down the latest image, it will also ensure that no one is running tests with an older version of the benchmark image.

We should be following this up with using a specific tag/version for each of the benchmark images as well, so that once we implement versioning in Ripsaw we can then accordingly have a branch in magazine/snafu with the same number. 
