### PR TITLE
changed dash to underscore for fio wrapper

### DIFF
--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -36,7 +36,7 @@ spec:
              for file in $(ls /tmp/fio/ | egrep ^fiojob); do
                cat /tmp/fio/$file;
                mkdir -p /tmp/fiod-{{ uuid }}/$file;
-               python /opt/snafu/fio-wrapper/fio-wrapper.py /tmp/host/hosts /tmp/fio/$file -s {{fiod.samples}} -d /tmp/fiod-{{ uuid }}/$file;
+               python /opt/snafu/fio_wrapper/fio_wrapper.py /tmp/host/hosts /tmp/fio/$file -s {{fiod.samples}} -d /tmp/fiod-{{ uuid }}/$file;
              done;"
         volumeMounts:
         - name: fio-volume


### PR DESCRIPTION
This change is needed because snafu is using invalid syntax for python
directory/file names