### PR TITLE
Added trap on error function

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ERRORED=false
+
 function check_full_trigger {
 python - <<END
 import os
@@ -159,10 +161,6 @@ function wait_for() {
   then
       echo "Timeout exceeded for: "$1
 
-      #Always provide the benchmark-operator logs
-      echo "Benchmark-operator logs:"
-      kubectl -n my-ripsaw logs --tail=40 -l name=benchmark-operator -c benchmark-operator
-
       counter=3
       until [ $counter -gt $# ]
       do
@@ -173,4 +171,13 @@ function wait_for() {
       return 1
   fi
   return 0
+}
+
+function error {
+  echo "Error caught. Dumping logs before exiting"
+  echo "Benchmark operator Logs"
+  kubectl -n my-ripsaw logs --tail=40 -l name=benchmark-operator -c benchmark-operator
+  echo "Ansible sidecar Logs"
+  kubectl -n my-ripsaw logs -l name=benchmark-operator -c ansible
+  ERRORED=true
 }

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up byowl"
   kubectl delete -f tests/test_crs/valid_byowl.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_byowl {

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up Fio"
   kubectl delete -f tests/test_crs/valid_fiod.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_fio {

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+  
   echo "Cleaning up iperf3"
   kubectl delete -f tests/test_crs/valid_iperf3.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_iperf {

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up pgbench"
   kubectl delete -n my-ripsaw benchmark/pgbench-benchmark
   kubectl delete -n my-ripsaw deployment/postgres
@@ -11,6 +16,7 @@ function finish {
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 # Note we don't test persistent storage here

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up Smallfile"
   kubectl delete -f tests/test_crs/valid_smallfile.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_smallfile {

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+  
   echo "Cleaning up sysbench"
   kubectl delete -f tests/test_crs/valid_sysbench.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_sysbench {

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up Uperf"
   kubectl delete -f tests/test_crs/valid_uperf.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_uperf {

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up Uperf"
   kubectl delete -f tests/test_crs/valid_uperf_serviceip.yaml
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_uperf_serviceip {

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-set -xeo pipefail
+set -xeEo pipefail
 
 source tests/common.sh
 
 function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
   echo "Cleaning up ycsb"
   kubectl delete -n my-ripsaw benchmark/ycsb-mongo-benchmark
   kubectl delete -n my-ripsaw statefulset/mongo
@@ -11,6 +16,7 @@ function finish {
   delete_operator
 }
 
+trap error ERR
 trap finish EXIT
 
 function functional_test_ycsb {


### PR DESCRIPTION
Error function gets triggered on any ERR return as well as exit code 1. It provides the logs of the benchmark operator as well as the new ansible sidecar. I removed the benchmark operator log dump from the wait_for function since it was now redundant.