### PR TITLE
wait_clean now deletes all not just pods, jobs, etc

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -27,9 +27,7 @@ function populate_test_list {
 }
 
 function wait_clean {
-  kubectl delete --all jobs --namespace my-ripsaw
-  kubectl delete --all deployments --namespace my-ripsaw
-  kubectl delete --all pods --namespace my-ripsaw
+  kubectl delete all --all -n my-ripsaw
   for i in {1..30}; do
     if [ `kubectl get pods --namespace my-ripsaw | grep bench | wc -l` -ge 1 ]; then
       sleep 5


### PR DESCRIPTION
To avoid leaving hanging resources such as statefulsets etc we can delete everything in the wait_clean function not just specific types.