### PR TITLE
Run CI tests in parallel

### DIFF
--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -20,14 +20,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: quay.io/benchmark-operator/benchmark-operator:master
+          image: quay.io/rht_perf_ci/benchmark-operator:master # 
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: benchmark-operator
-          image: quay.io/benchmark-operator/benchmark-operator:master
+          image: quay.io/rht_perf_ci/benchmark-operator:master # 
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -x
+
+source tests/common.sh
+
+ci_dir=$1
+ci_test=`echo $1 | sed 's/-/_/g'`
+
+cd $ci_dir
+
+# Apply the operator with customized namespace
+kubectl apply -f resources/namespace.yaml
+
+# Re-deploy operator requirements before each test
+operator_requirements
+
+# Test ci
+if /bin/bash tests/$ci_test.sh
+then
+  echo "$ci_dir: Successful"
+  echo "$ci_dir: Successful" >> ../ci_results
+else
+  echo "$ci_dir: Failed"
+  echo "$ci_dir: Failed" >> ../ci_results
+fi
+
+# Ensure that all operator resources have been cleaned up after each test as well as the namespace
+cleanup_operator_resources
+kubectl delete -f resources/namespace.yaml

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ update_operator_image
 
 mkdir gold
 cp -pr * gold/
-max_concurrent=3
+max_concurrent=2
 
 failed=()
 success=()
@@ -47,18 +47,17 @@ do
   cd ..
 done
 
-# Run tests in parallel. Currently 3 at a time.
-cat tests/my_tests | xargs -n 1 -P 3 ./run_test.sh
+# Run tests in parallel
+cat tests/my_tests | xargs -n 1 -P $max_concurrent ./run_test.sh
 
 # Get number of successes/failures
-success=`grep -c Successful ci_results`
-failed=0
-failed=`grep -c Failed ci_results`
+success=`grep Successful ci_results`
+failed=`grep Failed ci_results`
 echo "CI tests that passed: "$success
 echo "CI tests that failed: "$failed
 echo "Smoke test: Complete"
 
-if [ $failed -gt 0 ]
+if [ `grep -c Failed ci_results` -gt 0 ]
 then
   exit 1
 fi

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -21,9 +21,9 @@ function functional_test_byowl {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
-  byowl_pod=$(get_pod 'app=byowl' 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=200s" "200s" $byowl_pod
-  wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl jobs --timeout=300s" "300s" $byowl_pod
+  byowl_pod=$(get_pod 'app=byowl' 600)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=400s" "400s" $byowl_pod
+  wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl jobs --timeout=600s" "600s" $byowl_pod
   kubectl -n my-ripsaw logs "$byowl_pod" | grep "Test"
   echo "BYOWL test: Success"
 }

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -21,10 +21,10 @@ function functional_test_fio {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_fiod.yaml
-  pod_count 'app=fio-benchmark' 2 300
-  fio_pod=$(get_pod 'app=fiod-client' 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod --namespace my-ripsaw --timeout=200s" "200s" $fio_pod
-  wait_for "kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=500s" "500s" $fio_pod
+  pod_count 'app=fio-benchmark' 2 600
+  fio_pod=$(get_pod 'app=fiod-client' 600)
+  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod --namespace my-ripsaw --timeout=400s" "400s" $fio_pod
+  wait_for "kubectl wait --for=condition=complete -l app=fiod-client jobs --namespace my-ripsaw --timeout=1000s" "1000s" $fio_pod
   sleep 30
   # ensuring the run has actually happened
   kubectl logs "$fio_pod" --namespace my-ripsaw | grep "fio has successfully finished sample"

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -21,10 +21,10 @@ function functional_test_iperf {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
-  pod_count 'app=iperf3-bench-server' 1 300
-  iperf_client_pod=$(get_pod 'app=iperf3-bench-client' 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=200s" "200s" $iperf_client_pod
-  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=100s" "100s" $iperf_client_pod
+  pod_count 'app=iperf3-bench-server' 1 600
+  iperf_client_pod=$(get_pod 'app=iperf3-bench-client' 600)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=400s" "400s" $iperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client jobs --timeout=200s" "200s" $iperf_client_pod
   sleep 5
   # ensuring that iperf actually ran and we can access metrics
   kubectl logs "$iperf_client_pod" --namespace my-ripsaw | grep "iperf Done."

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -61,7 +61,7 @@ spec:
             - configMapRef:
                 name: postgres-config
 EOF
-  postgres_pod=$(get_pod 'app=postgres' 300)
+  postgres_pod=$(get_pod 'app=postgres' 600)
   # get the postgres pod IP
   postgres_ip=0
   counter=0
@@ -72,10 +72,10 @@ EOF
   done
   # deploy the test CR with the postgres pod IP
   sed s/host:/host:\ ${postgres_ip}/ tests/test_crs/valid_pgbench.yaml | kubectl apply -f -
-  pgbench_pod=$(get_pod 'app=pgbench-client' 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
-  wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
-  wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client -n my-ripsaw --timeout=300s" "300s" $pgbench_pod
+  pgbench_pod=$(get_pod 'app=pgbench-client' 600)
+  wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=200s" "200s" $pgbench_pod
+  wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=200s" "200s" $pgbench_pod
+  wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client -n my-ripsaw --timeout=600s" "600s" $pgbench_pod
   kubectl logs -n my-ripsaw $pgbench_pod | grep 'tps ='
   echo "pgbench test: Success"
 }

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -24,8 +24,8 @@ function functional_test_smallfile {
   sleep 15
   smallfile_pod=$(kubectl get pods -l app=smallfile-benchmark --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
   echo smallfile_pod $smallfile_pod
-  wait_for "kubectl wait --for=condition=Initialized pods/$smallfile_pod --namespace my-ripsaw --timeout=200s" "200s" $smallfile_pod
-  wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace my-ripsaw --timeout=100s" "100s" $smallfile_pod
+  wait_for "kubectl wait --for=condition=Initialized pods/$smallfile_pod --namespace my-ripsaw --timeout=400s" "400s" $smallfile_pod
+  wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark jobs --namespace my-ripsaw --timeout=200s" "200s" $smallfile_pod
   sleep 30
   # ensuring the run has actually happened
   kubectl logs "$smallfile_pod" --namespace my-ripsaw | grep "RUN STATUS"

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -21,10 +21,10 @@ function functional_test_sysbench {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
-  sysbench_pod=$(get_pod 'app=sysbench' 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=200s" "200s" $sysbench_pod
+  sysbench_pod=$(get_pod 'app=sysbench' 600)
+  wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=400s" "400s" $sysbench_pod
   # Higher timeout as it takes longer
-  wait_for "kubectl wait --for=condition=complete -l app=sysbench --namespace my-ripsaw jobs" "300s" $sysbench_pod
+  wait_for "kubectl wait --for=condition=complete -l app=sysbench --namespace my-ripsaw jobs" "600s" $sysbench_pod
   # sleep isn't needed as the sysbench is kind: job so once it's complete we can access logs
   # ensuring the run has actually happened
   kubectl logs "$sysbench_pod" --namespace my-ripsaw | grep "execution time"

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -21,10 +21,10 @@ function functional_test_uperf {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf.yaml
-  pod_count 'type=uperf-bench-server' 1 300
-  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
-  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=500s" "500s" $uperf_client_pod
+  pod_count 'type=uperf-bench-server' 1 600
+  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 600)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=400s" "400s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=1000s" "1000s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -21,10 +21,10 @@ function functional_test_uperf_serviceip {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
-  pod_count 'type=uperf-bench-server' 1 300
-  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
-  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=300s" "300s" $uperf_client_pod
+  pod_count 'type=uperf-bench-server' 1 600
+  uperf_client_pod=$(get_pod 'app=uperf-bench-client' 600)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=400s" "400s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client jobs --timeout=600s" "600s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running
   sleep 30

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -64,9 +64,9 @@ spec:
            - containerPort: 27017
 EOF
   kubectl apply -f tests/test_crs/valid_ycsb-mongo.yaml
-  ycsb_load_pod=$(get_pod 'name=ycsb-load' 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$ycsb_load_pod -n my-ripsaw --timeout=60s" "60s" $ycsb_load_pod
-  wait_for "kubectl wait --for=condition=Complete jobs -l name=ycsb-load -n my-ripsaw --timeout=300s" "300s" $ycsb_load_pod
+  ycsb_load_pod=$(get_pod 'name=ycsb-load' 600)
+  wait_for "kubectl wait --for=condition=Initialized pods/$ycsb_load_pod -n my-ripsaw --timeout=200s" "200s" $ycsb_load_pod
+  wait_for "kubectl wait --for=condition=Complete jobs -l name=ycsb-load -n my-ripsaw --timeout=600s" "600s" $ycsb_load_pod
   kubectl logs -n my-ripsaw $ycsb_load_pod | grep 'Starting test'
   echo "ycsb test: Success"
 }


### PR DESCRIPTION
Since we don't really care about the performance results when doing CI testing we should run multiple CI tests at once. This will set it to run 3 at a time. We may need to adjust timeouts up to account for the new load on the system. Additionally, we will need to validate the CI output is usable and not jumbled together.