### PR TITLE
reducing uperf test runtime for CI

### DIFF
--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -22,9 +22,9 @@ spec:
         - tcp
         - udp
       sizes:
-        - 16384
+        - 1024
         - 512
       nthrs:
         - 1
-        - 8
-      runtime: 10
+        - 2
+      runtime: 2


### PR DESCRIPTION
Just to reduce the runtime as current testing time takes over 500 seconds