### PR TITLE
ServiceIP bug

### DIFF
--- a/roles/uperf-bench/templates/service.yml.j2
+++ b/roles/uperf-bench/templates/service.yml.j2
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: uperf-service-{{ item }}-{{ trunc_uuid }}
   namespace: '{{ operator_namespace }}'
-spec:
-  selector:
+  labels:
     app: uperf-bench-server-{{ item }}
     type: uperf-bench-server-{{ trunc_uuid }}
+spec:
   ports:
   - name: uperf
     port: 20000


### PR DESCRIPTION
Now that the operator has its own svcip I noticed that we had a bug. We
are missing the labels totally for the svcip. This is to fix that.