### PR TITLE
Tests are now retried once upon failure

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -x
+
+ci_dir=$1
+ci_test=`echo $1 | sed 's/-/_/g'`
+retries=1
+
+figlet $ci_test
+
+cd $ci_dir
+
+source tests/common.sh
+
+count=0
+
+# Run the test up to a max of $retries
+while [ $count -le $retries ]
+do
+  wait_clean
+
+  # Test ci
+  if /bin/bash tests/$ci_test.sh > $ci_test.out 2>&1
+  then
+    # if the test passes update the results and complete
+    echo "$ci_dir: Successful"
+    echo "$ci_dir: Successful" > ci_results
+    echo "      <testcase classname=\"CI Results\" name=\"$ci_test\"/>" > results.xml
+    echo "$ci_test | Pass | $count" > results.markdown 
+    count=$retries
+  else
+    # if the test failed check if we have done the max retries
+    if $count -lt $retries
+    then
+      echo "$ci_dir: Failed. Retrying"
+      echo "$ci_dir: Failed. Retrying" >> $ci_test.out
+    else
+      echo "$ci_dir: Failed retry" 
+      echo "$ci_dir: Failed" > ci_results
+      echo "      <testcase classname=\"CI Results\" name=\"$ci_test\" status=\"$ci_test failed\">" > results.xml
+      echo "         <failure message=\"$ci_test failed\" type=\"test failure\"/>
+      </testcase>" >> results.xml
+      echo "$ci_test | Fail | $count" > results.markdown
+      echo "Logs for "$ci_dir
+
+      # Display the error log since we have failed to pass
+      cat $ci_test.out
+    fi
+  fi
+  ((count++))
+done
+wait_clean

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,13 @@ source tests/common.sh
 cleanup_operator_resources
 update_operator_image
 
+# Create a "gold" directory based off the current branch
+mkdir gold
+cp -pr * gold/
+
+# The maximum number of concurrent tests to run at one time (0 for unlimited)
+max_concurrent=1
+
 failed=()
 success=()
 
@@ -28,10 +35,9 @@ fi
 test_list="$(cat tests/iterate_tests)"
 echo "running test suit consisting of ${test_list}"
 
-pass=0
-
-testcount=0
-failcount=0
+# Massage the names into something that is acceptable for a namespace
+sed 's/.sh//g' tests/iterate_tests > tests/my_tests
+sed -i 's/_/-/g' tests/my_tests
 
 # Prep the results.xml file
 echo '<?xml version="1.0" encoding="UTF-8"?>
@@ -41,48 +47,50 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 # Prep the results.markdown file
 echo "Results for "$JOB_NAME > results.markdown
 echo "" >> results.markdown
-echo 'Test | Result' >> results.markdown
-echo '-----|-------' >> results.markdown
+echo 'Test | Result | Retries' >> results.markdown
+echo '-----|--------|--------' >> results.markdown
 
-# Iterate over the tests listed in test_list. For quickest testing of an individual workload have
-# its test listed first in $test_list
-for ci_test in `cat tests/iterate_tests`
+# Create individual directories for each test
+# If we run multiple tests at once this makes it easier
+for ci_dir in `cat tests/my_tests`
 do
-  # Re-deploy operator requirements before each test
-  operator_requirements
-
-  # Test ci
-  if /bin/bash tests/$ci_test
-  then
-    success=("${success[@]}" $ci_test)
-    echo "$ci_test: Successful"
-    echo "      <testcase classname=\"CI Results\" name=\"$ci_test\"/>" >> results.xml
-    echo "$ci_test | Pass" >> results.markdown
-  else
-    failed=("${failed[@]}" $ci_test)
-    pass=1
-    echo "$ci_test: Failed"
-    echo "      <testcase classname=\"CI Results\" name=\"$ci_test\" status=\"$ci_test failed\">" >> results.xml
-    echo "         <failure message=\"$ci_test failure\" type=\"test failure\"/>
-      </testcase>" >> results.xml
-    echo "$ci_test | Fail" >> results.markdown
-    ((failcount++))
-  fi
-
-  ((testcount++))
-  # Ensure that all operator resources have been cleaned up after each test
-  cleanup_operator_resources
+  mkdir $ci_dir
+  cp -pr gold/* $ci_dir/
 done
 
-echo "CI tests that passed: "${success[@]}
-echo "CI tests that failed: "${failed[@]}
+# Run tests in parallel up to $max_concurrent at a time.
+xargs -n 1 -a tests/my_tests -P $max_concurrent ./run_test.sh 
+
+
+# Update and close JUnit test results.xml and markdown file
+for test_dir in `cat tests/my_tests`
+do
+  cat $test_dir/results.xml >> results.xml
+  cat $test_dir/results.markdown >> results.markdown
+  cat $test_dir/ci_results >> ci_results
+done
+
+# Get number of successes/failures
+testcount=`wc -l ci_results`
+success=`grep Successful ci_results | awk -F ":" '{print $1}'`
+failed=`grep Failed ci_results | awk -F ":" '{print $1}'`
+failcount=`grep -c Failed ci_results`
+echo "CI tests that passed: "$success
+echo "CI tests that failed: "$failed
 echo "Smoke test: Complete"
 
-# Update and close JUnit test results.xml
 echo "   </testsuite>
 </testsuites>" >> results.xml
 
 sed -i "s/NUMTESTS/$testcount/g" results.xml
 sed -i "s/NUMFAILURES/$failcount/g" results.xml
 
-exit $pass
+if [ `grep -c Failed ci_results` -gt 0 ]
+then
+  exit 1
+fi
+  
+# Clean up our created directories
+rm -rf gold test-* ci_results
+
+exit 0

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -104,6 +104,7 @@ function pod_count () {
 }
 
 function apply_operator {
+  operator_requirements
   kubectl apply -f resources/operator.yaml
   ripsaw_pod=$(get_pod 'name=benchmark-operator' 300)
   kubectl wait --for=condition=Initialized "pods/$ripsaw_pod" --namespace my-ripsaw --timeout=60s


### PR DESCRIPTION
To avoid having to re-run the entire test bed for a single (possibly transient failure) we re-run a failed test once.

Additionally, this adds the following changes to the CI scripts:
- Added a "Retries" column in the github markdown output
- Broke the test.sh script into two, adding run_test.sh
- run_test.sh takes a parameter (the test) to be run and cycles through the test until pass or X (now 1) retries are met
- Added operator_requirements to apply_operator to ensure everything is there before we run
- Test output is predominately suppressed unless we fail, at which point it is printed to the CI console.
- Added the max_concurrent (currently 1) variable which can be used if we decide to run tests in parallel in the future. 