### PR TITLE
update fio CR example file for fio & storageclass units neuroses

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -18,16 +18,19 @@ spec:
       jobs:
         - read
         - write
+      # NOTE: fio units should be given in IEC standard long format, i.e. KiB, MiB, GiB, TiB
       bs:
-        - 64Ki
+        - 64KiB
       numjobs:
         - 1
       iodepth: 4
       runtime: 60
       ramp_time: 5
-      filesize: 2Gi
+      # NOTE: fio units should be given in IEC standard long format, i.e. KiB, MiB, GiB, TiB
+      filesize: 2GiB
       log_sample_rate: 1000
       #storageclass: rook-ceph-block
+      # NOTE: storageclass units should be given in IEC standard short format, i.e. Ki, Mi, Gi, Ti
       #storagesize: 5Gi
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -14,13 +14,13 @@ spec:
         - read
         - write
       bs:
-        - 64Ki
+        - 64KiB
       numjobs:
         - 1
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1Gi
+      filesize: 1GiB
       log_sample_rate: 1000
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #

--- a/tests/test_crs/valid_fiod_store.yaml
+++ b/tests/test_crs/valid_fiod_store.yaml
@@ -18,13 +18,13 @@ spec:
         - read
         - write
       bs:
-        - 64Ki
+        - 64KiB
       numjobs:
         - 1
       iodepth: 4
       runtime: 3
       ramp_time: 1
-      filesize: 1Gi
+      filesize: 1GiB
       log_sample_rate: 1000
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #


### PR DESCRIPTION
Our fio jobfile defaults include `kb_base=1000`, which actually does the opposite of what it may sound like -- this setting enforces IEC power-of-2 standard for unit so that KiB=1024 and KB=1000. Without this, fio does the exact opposite.

This was added to the default jobfile in a previous PR because unit references in the CR file for PVCs require IEC units (this cannot be changed), so this `kb_base=1000` theoretically standardizes the units used in the CR.

It turns out that though the fio documentation implies that it will accept both shorthand **Ki** and long-form **KiB** for the IEC units, it actually treats both **K** and **Ki** and standard base-10 units and only **KiB** ans IEC power-of-2. This isn't really evident until you attempt to run directio writes, in which case it expects the `bs` to be a multiple of **4KiB**, and therefore values such as **4Ki** or **4K** will result in a base-10 value of 4000 and will cause the IO to fail as invalid argument.

Unfortunately, it also seems that the [K8S resource model](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md) has the opposite problem -- it only accepts the shorthand **Ki** for units and will choke on **KiB**.

Because of this, we need to set the units in the CR explicitly for the accepted unit formats of each.

Both fio and the K8S resource model are behaving incorrectly, IMO, and I will work on bug reports for each.