### PR TITLE
Fixing the bad looping

### DIFF
--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -33,11 +33,14 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - "cat /tmp/host/hosts;
-             for file in $(ls /tmp/fio/ | egrep ^fiojob); do
-               cat /tmp/fio/$file;
-               mkdir -p /tmp/fiod-{{ uuid }}/$file;
-               python /opt/snafu/fio_wrapper/fio_wrapper.py /tmp/host/hosts /tmp/fio/$file -s {{fiod.samples}} -d /tmp/fiod-{{ uuid }}/$file;
-             done;"
+{% for job in fiod.jobs %}
+{% for bs in fiod.bs %}
+{% for numjobs in fiod.numjobs %}
+             cat /tmp/fio/fiojob-{{job}}-{{bs}}-{{numjobs}}; mkdir -p /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{bs}}-{{numjobs}}; python /opt/snafu/fio_wrapper/fio_wrapper.py /tmp/host/hosts /tmp/fio/fiojob-{{job}}-{{bs}}-{{numjobs}} -s {{fiod.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{bs}}-{{numjobs}};
+{% endfor %}
+{% endfor %}
+{% endfor %}
+             echo run finished"
         volumeMounts:
         - name: fio-volume
           mountPath: "/tmp/fio"

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -45,12 +45,18 @@ spec:
              export ips=$(hostname -I);
              while true; do
                if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true' ]]; then
-                 for file in $(ls /tmp/uperf-test/ | egrep ^uperf); do
-                   cat /tmp/uperf-test/$file;
-                   for i in `seq 1 {{uperf.samples}}`; do
-                     python /opt/snafu/uperf-wrapper/uperf-wrapper.py -w /tmp/uperf-test/$file -r $i;
-                   done;
+{% for test in uperf.test_types %}
+{% for proto in uperf.protos %}
+{% for size in uperf.sizes %}
+{% for nthr in uperf.nthrs %}
+                 cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}};
+                 for i in `seq 1 {{uperf.samples}}`; do
+                   python /opt/snafu/uperf-wrapper/uperf-wrapper.py -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}} -r $i;
                  done;
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}
                else
                  continue;
                fi;


### PR DESCRIPTION
We're looping on the list of files, so ripsaw wasn't running benchmark
in the order of parameters passed.