### PR TITLE
add wait: true to containers to wait for finializers

### DIFF
--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -16,4 +16,5 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["{{ byowl.commands }}"]
         image: "{{ byowl.image }}"
+        wait: true
       restartPolicy: OnFailure

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -15,6 +15,7 @@ spec:
       - name: fio-client
         image: "quay.io/cloud-bulldozer/fio:latest"
         imagePullPolicy: Always
+        wait: true
         env:
           - name: uuid
             value: "{{ uuid }}"

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -29,6 +29,7 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 8765
+        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "fio --server"

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -16,6 +16,7 @@ spec:
           image: quay.io/cloud-bulldozer/fs-drift:master
           command: ["/bin/sh", "-c"]
           workingDir: /opt/fs-drift/
+          wait: true
           args:
             - set -x;
               export TMPDIR=/var/tmp/fs-drift-output;

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -22,6 +22,7 @@ spec:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
         imagePullPolicy: Always
+        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "iperf3 -c {{ item.status.podIP }} -p {{ iperf3.port }} --{{ iperf3.transmit_type }} {{ iperf3.transmit_value }} -l {{ iperf3.length_buffer }} -P {{ iperf3.streams }} -w {{ iperf3.window_size }} -M {{ iperf3.mss }} -S {{ iperf3.ip_tos }} -O {{ iperf3.omit_start }} {{ iperf3.extra_options_client }}"

--- a/roles/iperf3-bench/templates/client_store.yml.j2
+++ b/roles/iperf3-bench/templates/client_store.yml.j2
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
+        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "mkdir -p {{results.path}}/iperf3-{{ uuid }};

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -15,6 +15,7 @@ spec:
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/iperf3:latest"
+    wait: true
     command: ["/bin/sh", "-c"]
     args:
       - "iperf3 -s -p {{ iperf3.port }} {{ iperf3.extra_options_server }}"

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: benchmark
         image: "{{ pgb_base_image }}:{{ pgb_version }}"
+        wait: true
         env:
           - name: PGPASSWORD
             value: '{{ item.1.password }}'

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -17,6 +17,7 @@ spec:
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /root/smallfile-master/
+          wait: true
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};
               export TMPDIR=/tmp

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -18,6 +18,7 @@ spec:
         args: ["/tmp/sysbenchScript"]
         image: "quay.io/cloud-bulldozer/sysbench:latest"
         imagePullPolicy: Always
+        wait: true
         volumeMounts:
         - name: sysbench-volume
           mountPath: "/tmp/"

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -14,6 +14,7 @@ spec:
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/uperf:latest"
+    wait: true
     command: ["/bin/sh","-c"]
     args: ["uperf -s -v -P 20000"]
   restartPolicy: OnFailure

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -22,6 +22,7 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/uperf:latest"
+        wait: true
         command: ["/bin/sh", "-c"]
         args:
 {% if uperf.serviceip is sameas true %}


### PR DESCRIPTION
In some cases (particularly in minishift) the containers would go to a completed state prior to all the logs being written. This would cause issues in CI where we would get false failures since it would be unable to find the particular verification string in the log output.