### PR TITLE
switch smallfile to using run_snafu.py

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -4,6 +4,11 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  test_user: homer_simpson
+  clustername: aws-2009-09-10
+  es_server: my.elasticsearch.server
+  es_port: 9020
+  es_index: ripsaw-smallfile
   workload:
     name: smallfile
     args:

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -11,6 +11,7 @@ spec:
       labels:
         app: smallfile-benchmark-{{ trunc_uuid }}
     spec:
+      restartPolicy: Never
       containers:
         - name: benchmark-server
           image: "quay.io/cloud-bulldozer/smallfile:master"

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -51,7 +51,7 @@ spec:
               --top {{smallfile_path}}/smallfile_test_data 
               --dir /var/tmp/RESULTS 
               --yaml-input-file /tmp/smallfile/smallfilejob ;
-              echo RUN STATUS DONE
+              if [ $? = 0 ] ; then echo RUN STATUS DONE ; else exit 1 ; fi
           volumeMounts:
             - name: config-volume
               mountPath: "/tmp/smallfile"
@@ -59,6 +59,7 @@ spec:
             - name: ceph-volume
               mountPath: "{{ smallfile_path }}"
 {% endif %}
+      restartPolicy: Never
       volumes:
         - name: config-volume
           configMap:

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -20,6 +20,21 @@ spec:
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
           wait: true
+          env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user }}"
+          - name: clustername
+            value: "{{ clustername }}"
+{% if es_server %}
+          - name: es
+            value: "{{ es_server }}"
+          - name: es_port
+            value: "{{ es_port }}"
+          - name: es_index
+            value: "{{ es_index }}"
+{% endif %}
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};
               export TMPDIR=/tmp

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -14,24 +14,26 @@ spec:
       containers:
         - name: benchmark-server
           image: "quay.io/cloud-bulldozer/smallfile:master"
+          # example of how to debug using your own workload image
+          #image: "quay.io/bengland2/smallfile:master"
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
-          workingDir: /root/smallfile-master/
+          workingDir: /opt/snafu
           wait: true
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};
               export TMPDIR=/tmp
-              arr=$(python <<< "print(' '.join({{smallfile.operation}}))");
+              arr=$(python <<< "print(','.join({{smallfile.operation}}))");
               rm -rf {{smallfile_path}}/RESULTS ;
               mkdir -p {{smallfile_path}}/RESULTS;
               mkdir -p {{smallfile_path}}/smallfile_test_data;
-              for i in ${arr[@]};do
-              echo RUNNING_OPERATION_$i;
-              cat /tmp/smallfile/smallfilejob;
-              python smallfile_cli.py --operation ${i} --yaml-input-file /tmp/smallfile/smallfilejob --output-json {{smallfile_path}}/RESULTS/SMALLFILE_${i}_RUN_RESULT;
-              sleep 5;
-              done;
-              rm -rf {{ smallfile_path }}/smallfile_test_data;
+              python /opt/snafu/run_snafu.py 
+              --samples {{smallfile.samples}}
+              --tool smallfile 
+              --operations $arr 
+              --top {{smallfile_path}}/smallfile_test_data 
+              --dir /var/tmp/RESULTS 
+              --yaml-input-file /tmp/smallfile/smallfilejob ;
               echo RUN STATUS DONE
           volumeMounts:
             - name: config-volume

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -6,6 +6,7 @@ metadata:
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
+  backoffLimit: 0
   template:
     metadata:
       labels:

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -21,13 +21,13 @@ spec:
           workingDir: /opt/snafu
           wait: true
           env:
+{% if es_server is defined %}
           - name: uuid
             value: "{{ uuid }}"
           - name: test_user
             value: "{{ test_user }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if es_server %}
           - name: es
             value: "{{ es_server }}"
           - name: es_port
@@ -43,7 +43,9 @@ spec:
               mkdir -p {{smallfile_path}}/RESULTS;
               mkdir -p {{smallfile_path}}/smallfile_test_data;
               python /opt/snafu/run_snafu.py 
+{% if smallfile.samples is defined %}
               --samples {{smallfile.samples}}
+{% endif %}
               --tool smallfile 
               --operations $arr 
               --top {{smallfile_path}}/smallfile_test_data 

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -9,6 +9,6 @@ spec:
     args:
       clients: 1
       operation: ["create", "read", "append", "delete"]
-      threads: 5
+      threads: 1
       file_size: 64
       files: 100


### PR DESCRIPTION
Do not merge or test before snafu PR 50 is merged!
Using this branch I ran a 3-sample multi-operation smallfile test in AWS Ceph cluster.
take out loop for different operations
make operation list a CSV list for run_snafu.py smallfile_wrapper
no smallfile-master dir anymore