### PR TITLE
Multus support

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: myk8scluster
+  #elasticsearch:
+  #   server: elk.server.com
+  #   port: 9200
+  #test_user: username_to_attach_to_metadata
   workload:
     # cleanup: true
     name: uperf
@@ -12,6 +16,8 @@ spec:
       serviceip: false
       hostnetwork: false
       pin: false
+      multus:
+        enabled: false
       pin_server: "node-0"
       pin_client: "node-1"
       samples: 1

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -7,6 +7,10 @@ metadata:
   labels:
     app : uperf-bench-server-{{item}}-{{ trunc_uuid }}
     type : uperf-bench-server-{{ trunc_uuid }}
+{% if uperf.multus.enabled is sameas true %}
+  annotations:
+    k8s.v1.cni.cncf.io/networks: {{ uperf.multus.server}}
+{% endif %}
 spec:
 {% if uperf.hostnetwork is sameas true %}
   hostNetwork : true

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: uperf-bench-client-{{ trunc_uuid }}
+{% if uperf.multus.enabled is sameas true %}
+      annotations:
+        k8s.v1.cni.cncf.io/networks: {{ uperf.multus.client }}
+{% endif %}
     spec:
 {% if uperf.hostnetwork is sameas true %}
       hostNetwork : true
@@ -27,9 +31,13 @@ spec:
         args:
 {% if uperf.serviceip is sameas true %}
           - "export serviceip=true;
-             export h={{item.spec.clusterIP}};
+            export h={{item.spec.clusterIP}};
+{% else %}
+{% if uperf.multus.client is defined %}
+          - "export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
           - "export h={{item.status.podIP}};
+{% endif %}
 {% endif %}
 {% if elasticsearch is defined %}
 {% if elasticsearch.server is defined %}

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -13,6 +13,8 @@ spec:
       pin: false
       pin_server: "node-0"
       pin_client: "node-1"
+      multus:
+        enabled: false
       samples: 2
       pair: 1
       test_types:

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -1,31 +1,29 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: uperf-benchmark
-  namespace: my-ripsaw
+  name: example-benchmark
+  namespace: ripsaw
 spec:
-  clustername: myk8scluster
-  #elasticsearch:
-  #   server: elk.server.com
-  #   port: 9200
-  #test_user: username_to_attach_to_metadata
+  cleanup: false
   workload:
-    # cleanup: true
     name: uperf
     args:
-      serviceip: false
       hostnetwork: false
+      serviceip: true
       pin: false
       pin_server: "node-0"
       pin_client: "node-1"
-      samples: 1
+      samples: 2
       pair: 1
+      multus:
+        enabled: false
       test_types:
         - stream
+        - rr
       protos:
         - tcp
+        - udp
       sizes:
         - 16384
-      nthrs:
-        - 1
-      runtime: 30
+        - 512
+      runtime: 10


### PR DESCRIPTION
Adding Multus Support for macvlan tested.

User must create port per pod, multi-pod not supported.