### PR TITLE
smallfile_cli.py is in /usr/local/bin, run the script directly

### DIFF
--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -28,7 +28,7 @@ spec:
               for i in ${arr[@]};do
               echo RUNNING_OPERATION_$i;
               cat /tmp/smallfile/smallfilejob;
-              python smallfile_cli.py --operation ${i} --yaml-input-file /tmp/smallfile/smallfilejob --output-json {{smallfile_path}}/RESULTS/SMALLFILE_${i}_RUN_RESULT;
+              smallfile_cli.py --operation ${i} --yaml-input-file /tmp/smallfile/smallfilejob --output-json {{smallfile_path}}/RESULTS/SMALLFILE_${i}_RUN_RESULT;
               sleep 5;
               done;
               rm -rf {{ smallfile_path }}/smallfile_test_data;


### PR DESCRIPTION
smallfile_cli.py is in /usr/local/bin, when run with python the PATH variable doesn't include /usr/local/bin which causes the job to fail. Invoke the
cli directly instead.

Fixes: https://github.com/cloud-bulldozer/ripsaw/issues/230

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>