### PR TITLE
Adding backpack/stockpile to Ripsaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ advantage of the reconciliation loop, these two benchmarks need to be rewritten.
 ## Contributing
 [Contributing](CONTRIBUTE.md)
 
+## Metadata Collection
+[Metadata Collection](docs/metadata.md)
+
 ## Community
 Key Members(slack_usernames): aakarsh, dblack or rook
 * [**#sig-scalability on Kubernetes Slack**](https://kubernetes.slack.com)

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,0 +1,196 @@
+# Metadata Collection
+
+How To:
+* [How it Works](#how-it-works)
+* [Enable Collection](#enable-collection)
+* [Additional Options](#additional-options)
+* [Running Additional Collections](#running-additional-collections)
+
+# How it Works
+
+The metadata collection is done through the use of [Stockpile](https://github.com/cloud-bulldozer/stockpile), [Backpack](https://github.com/cloud-bulldozer/backpack) and [Scribe](https://github.com/cloud-bulldozer/scribe).
+The data is then uploaded to a defined Elasticsearch instance.
+
+When launching your benchmark, if enabled, the metadata collection container (backpack)
+will launch as a DaemonSet on all nodes in the cluster. It will then run stockpile
+to gather data and then push that information up to Elasticsearch.
+
+It runs the data collection/upload immediately upon launch and will not enter "Ready"
+state until the initial data collection/upload has completed. Once this is done,
+your benchmark will then launch and continue as normal. 
+
+NOTE: The backpack pods will not complete/terminate until you delete your benchmark.
+This is done to allow additional collections to be done as an ad-hoc basis as well.
+
+# Enable Collection
+
+By default metadata collection is turned off. 
+To enable collection:
+
+- Open the benchmark yaml that you will be running (for example byowl below)
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/jtaleric/uperf:testing"
+      clients: 1
+      commands: "echo Test"
+```
+
+- Add ```metadata_collection: true``` to the spec section of the yaml
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  metadata_collection: true
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/jtaleric/uperf:testing"
+      clients: 1
+      commands: "echo Test"
+```
+
+The metadata collection will now be enabled however as there is no Elasticsearch information
+defined it will fail.
+
+- Add the Elasticsearch server and Port information
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "my.elastic.server.foo"
+    port: 9200
+  metadata_collection: true
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/jtaleric/uperf:testing"
+      clients: 1
+      commands: "echo Test"
+```
+
+The metadata collection will now run as described previously and continue to
+the defined benchmark.
+
+# Additional Options
+
+There are a few additional options that can be enabled to enahnce the amount
+of data collected.
+
+## Privleged Pods
+
+By default, pods are run in an unprivledged state. While this makes permissions
+a lesser issue, it does limit the amount of data collected. For example, dmidecode
+requires privledges to read the memory information and generate the data.
+
+To enable privleged pods set:
+```
+metadata_privledged: true
+```
+
+In the spec section of the benchmark yaml as outlined for the other variables.
+
+## Additional k8s Information
+
+There are multiple kubernetes (k8s) based modules that are run in stockpile.
+These modules are not accessable by default as the default service account
+that runs the pod does not have the required privileges to access them. 
+
+To allow the Daemon Set's pods view permissions on the cluster you can apply
+the following yml files to create a service account with the appropriate 
+privileges.
+
+The following assumes setting the ```metadata_sa``` and ```operator_namespace``` variables.
+
+Create the service account:
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ metadata_sa }}"
+  namespace: "{{ operator_namespace }}"
+```
+
+Create the secret token for the service account:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ metadata_sa }}"
+  namespace: "{{ operator_namespace }}"
+  annotations:
+    kubernetes.io/service-account.name: "{{ metadata_sa }}"
+type: kubernetes.io/service-account-token
+```
+
+Create the Cluster Role Binding to allow the service account
+View permissions on the cluster:
+
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ metadata_sa }}"
+  namespace: "{{ operator_namespace }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: {{ metadata_sa }}
+  namespace: {{ operator_namespace }}
+```
+
+Once created, define the ```metadata_sa``` variable in the spec section
+along side the other metadata variables and apply your benchmark. Per 
+our example:
+
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "my.elastic.server.foo"
+    port: 9200
+  metadata_collection: true
+  metadata_sa: backpack-view
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/jtaleric/uperf:testing"
+      clients: 1
+      commands: "echo Test"
+```
+
+# Running Additional Collections
+
+While upon initial creation metadata is collected, it may be useful to collect
+additional runs of data at other times. To do this you will need to loop through
+each backpack Pod and exec the python command below:
+```
+python3 stockpile-wrapper-always.py -s [es_server] -p [es_port] -u [uuid]
+```
+Where es_server and es_port and the Elasticsearch server and port to index to.
+The UUID can be any uuid string you would like (if you do not supply one it
+will create one for you and you will see it defined in the output). On the
+initial run at boot this is the same UUID as the benchmark UUID.

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,7 +11,7 @@
     register: cr_state
 
   - debug:
-      msg: "{{cr_state}}"
+      msg: "{{ cr_state }}"
 
   - name: Set Workload UUID
     block:
@@ -57,70 +57,78 @@
         trunc_uuid: "{{ cr_state.resources[0].status.suuid }}"
 
     - include_role:
-        name: "uperf-bench"
-      vars:
-        uperf: "{{ workload.args }}"
-      when: workload.name == "uperf"  and workload.args.pair > 0
+        name: backpack
+      when: metadata_collection | default(false) | bool
 
-    - include_role:
-        name: "iperf3-bench"
-      vars:
-        iperf3: "{{ workload.args }}"
-      when: workload.name == "iperf3" and workload.args.pairs > 0
+    - block:
 
-    - include_role:
-        name: sysbench
-      vars:
-        sysbench : "{{ workload.args }}"
-      when: workload.name == "sysbench" and workload.args.enabled is defined and workload.args.enabled
+      - include_role:
+          name: "uperf-bench"
+        vars:
+          uperf: "{{ workload.args }}"
+        when: workload.name == "uperf"  and workload.args.pair > 0
 
-    - include_role:
-        name: "load-ycsb"
-      vars:
-        ycsb: "{{ workload.args }}"
-      when: workload.name == "ycsb" and workload.args.workloads | length > 0
+      - include_role:
+          name: "iperf3-bench"
+        vars:
+          iperf3: "{{ workload.args }}"
+        when: workload.name == "iperf3" and workload.args.pairs > 0
 
-    - include_role:
-        name: "ycsb-bench"
-      vars:
-        ycsb: "{{ workload.args }}"
-      with_items: '{{ workload.args.workloads }}'
-      when: workload.name == "ycsb" and workload.args.workloads | length > 0
+      - include_role:
+          name: sysbench
+        vars:
+          sysbench : "{{ workload.args }}"
+        when: workload.name == "sysbench" and workload.args.enabled is defined and workload.args.enabled
 
-    - include_role:
-        name: "byowl"
-      vars:
-        byowl: "{{ workload.args }}"
-      when: workload.name == "byowl" and workload.args.clients > 0
+      - include_role:
+          name: "load-ycsb"
+        vars:
+          ycsb: "{{ workload.args }}"
+        when: workload.name == "ycsb" and workload.args.workloads | length > 0
 
-    - include_role:
-        name: "fio-distributed"
-      vars:
-        fiod: "{{ workload.args }}"
-      when: workload.name == "fio_distributed" and workload.args.servers > 0
+      - include_role:
+          name: "ycsb-bench"
+        vars:
+          ycsb: "{{ workload.args }}"
+        with_items: '{{ workload.args.workloads }}'
+        when: workload.name == "ycsb" and workload.args.workloads | length > 0
 
-    - include_role:
-        name: "pgbench"
-      vars:
-        pgbench: "{{ workload.args }}"
-      when: workload.name == "pgbench" and workload.args.clients > 0
+      - include_role:
+          name: "byowl"
+        vars:
+          byowl: "{{ workload.args }}"
+        when: workload.name == "byowl" and workload.args.clients > 0
 
-    - include_role:
-        name: "smallfile-bench"
-      vars:
-        smallfile: "{{ workload.args }}"
-      when: workload.name == "smallfile" and workload.args.clients > 0
+      - include_role:
+          name: "fio-distributed"
+        vars:
+          fiod: "{{ workload.args }}"
+        when: workload.name == "fio_distributed" and workload.args.servers > 0
 
-    - include_role:
-        name: "fs-drift"
-      vars:
-        fs_drift: "{{ workload.args }}"
-      when: workload.name == "fs-drift" and workload.args.worker_pods > 0
+      - include_role:
+          name: "pgbench"
+        vars:
+          pgbench: "{{ workload.args }}"
+        when: workload.name == "pgbench" and workload.args.clients > 0
 
-    - include_role:
-        name: "hammerdb"
-      vars:
-        hammerdb: "{{ workload.args }}"
-      when: workload.name == "hammerdb" 
+      - include_role:
+          name: "smallfile-bench"
+        vars:
+          smallfile: "{{ workload.args }}"
+        when: workload.name == "smallfile" and workload.args.clients > 0
+
+      - include_role:
+          name: "fs-drift"
+        vars:
+          fs_drift: "{{ workload.args }}"
+        when: workload.name == "fs-drift" and workload.args.worker_pods > 0
+
+      - include_role:
+          name: "hammerdb"
+        vars:
+          hammerdb: "{{ workload.args }}"
+        when: workload.name == "hammerdb" 
+
+      when: cr_state.resources[0].status.complete != "Metadata Collecting"
       
     when: cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool

--- a/roles/backpack/tasks/main.yml
+++ b/roles/backpack/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+- name: Get benchmark state
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: cr_state
+
+- k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: "Metadata Collecting"
+      complete: false
+  when: cr_state.resources[0].status.state is not defined
+
+- name: Get benchmark state 
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: cr_state
+
+- name: Get DaemonSet state
+  k8s_facts:
+    api_version: apps/v1
+    kind: DaemonSet
+    name: "backpack-{{ trunc_uuid }}"
+    namespace: "{{ operator_namespace }}"
+  register: my_daemonset
+  ignore_errors: true
+
+- name: set original generation fact
+  set_fact:
+    backpack_orig_gen: "{{ my_daemonset | json_query('resources[].metadata.generation')|first | default('1') }}"
+
+- name: Ensure present daemonset
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'backpack.yml') | from_yaml }}"
+
+- name: Get DaemonSet Status
+  k8s_facts:
+    api_version: apps/v1
+    kind: DaemonSet
+    name: "backpack-{{ trunc_uuid }}"
+    namespace: "{{ operator_namespace }}"
+  register: my_daemonset
+
+- block:
+
+  - name: set current generation fact
+    set_fact:
+      backpack_cur_gen: "{{ my_daemonset | json_query('resources[].metadata.generation')|first }}"
+
+  - k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Metadata Collecting"
+        complete: false
+    when: backpack_orig_gen != backpack_cur_gen
+
+  - name: Get benchmark state
+    k8s_facts:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+    register: cr_state
+
+  - block:
+  
+    - name: Get initial pod list
+      k8s_facts:
+        kind: Pod
+        namespace: "{{ operator_namespace }}"
+        label_selectors:
+          - name = backpack-{{ trunc_uuid }}
+      register: pods
+    
+    - block:
+
+      - k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            state: null
+            complete: false
+      
+      - name: Get benchmark state
+        k8s_facts:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+        register: cr_state
+
+      when: backpack_cur_gen == pods | json_query('resources[].metadata.labels."pod-template-generation"')|first and "ContainersNotReady" not in pods | json_query('resources[].status.conditions[].reason')
+
+    when: backpack_orig_gen == backpack_cur_gen
+
+  when: "my_daemonset | json_query('resources[].status.desiredNumberScheduled') == my_daemonset | json_query('resources[].status.numberReady') and my_daemonset | json_query('resources[].status.numberReady') != 0 "

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "backpack-{{ trunc_uuid }}"
+  namespace: "{{ operator_namespace }}"
+spec:
+  selector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+        - backpack-{{ trunc_uuid }}
+  template:
+    metadata:
+      labels:
+        name: backpack-{{ trunc_uuid }}
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: backpack
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} ; sleep infinity"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        readinessProbe:
+          exec:
+            command:
+              - ls
+              - /tmp/stockpile.json
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 120
+      serviceAccountName: {{ metadata_sa | default('default') }}
+      terminationGracePeriodSeconds: 30

--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+source tests/common.sh
+
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up backpack"
+  kubectl delete -f tests/test_crs/valid_backpack.yaml
+  delete_operator
+}
+
+trap error ERR
+trap finish EXIT
+
+function functional_test_byowl {
+  figlet $(basename $0)
+  apply_operator
+  kubectl apply -f tests/test_crs/valid_backpack.yaml
+  uuid=$(get_uuid 20)
+
+  node_count=`kubectl get nodes | grep -v NAME | wc -l`
+  until [ `kubectl -n my-ripsaw get daemonsets backpack-$uuid | grep -v NAME | awk '{print $4}'` -eq $node_count ] ; do
+    sleep 5
+  done
+  echo $backpack_pod
+
+  for pod in `kubectl -n my-ripsaw get pods -l name=backpack-$uuid | grep -v NAME | awk '{print $1}'`
+  do
+    if [[ `kubectl -n my-ripsaw exec $pod -- ls /tmp/stockpile.json` ]]
+    then
+      echo "Found stockpile.json on "$pod
+    else
+      echo "Could not find stockpile.json on "$pod
+      echo "Backpack test: Fail"
+      exit 1
+    fi
+  done
+
+  echo "Backpack test: Success"
+}
+
+functional_test_byowl

--- a/tests/test_crs/valid_backpack.yaml
+++ b/tests/test_crs/valid_backpack.yaml
@@ -1,0 +1,16 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/jtaleric/uperf:testing"
+      clients: 1
+      commands: "echo Test"

--- a/tests/test_list
+++ b/tests/test_list
@@ -1,3 +1,4 @@
+test_backpack.sh
 test_ycsb.sh
 test_fiod.sh
 test_fs-drift.sh


### PR DESCRIPTION
Adding backpack/stockpile to ripsaw operator image. 

If the following are set in the workload yaml it will execute the backpack daemonset to be created.
```
...
spec:
  es_server: "my.elastic.server.foo"
  es_port: 9200
  metadata_collection: true
  workload: ...
```

Additional options can be defined for privledged pods as well as passing a kubeconfig to the image for added data collection per https://github.com/dry923/ripsaw/blob/backpack/docs/metadata.md.