### PR TITLE
Adding metadata_complete flag to ripsaw crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ a performance baseline of Kubernetes cluster on your provider.
 
 | Workload                       | Use                    | Status in Operator | Reconciliation usage       | VM support (kubevirt) |
 | ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- |
-| [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 30second  | Preview               |
-| [Iperf3](docs/iperf3.md)       | Network Performance    | Working            |  Used, default : 30second  | Not Supported         |
-| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 30second  | Not Supported         |
-| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 30second  | Not Supported         |
+| [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Preview               |
+| [Iperf3](docs/iperf3.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported         |
+| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Not Supported         |
+| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported         |
 | [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Not used                  | Not Supported         |
-| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 30second  | Not Supported         |
+| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported         |
 | [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Not used                  | Not Supported         |
-| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 30second  | Not Supported         |
+| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported         |
 | [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                  | Not Supported         |
 | [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Not used                  | Not Supported         |
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -28,37 +28,23 @@
           uuid: "{{ uuid }}"
           complete: false
           suuid: "{{ trunc_uuid }}"
+          metadata: "not collected"
 
-    - name: Get updated state
-      k8s_facts:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: '{{ meta.name }}'
-        namespace: '{{ operator_namespace }}'
-      register: cr_state
     when: workload is defined and cr_state.resources[0].status is not defined
-
-  - name: Get state
-    k8s_facts:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: '{{ meta.name }}'
-      namespace: '{{ operator_namespace }}'
-    register: cr_state
 
   - name: Run Workload
     block:
 
-    - debug:
-        msg: "{{cr_state}}"
-
     - set_fact:
         uuid: "{{ cr_state.resources[0].status.uuid }}"
         trunc_uuid: "{{ cr_state.resources[0].status.suuid }}"
-
-    - include_role:
-        name: backpack
-      when: metadata_collection | default(false) | bool
+    
+    - block:
+      
+      - include_role:
+          name: backpack
+    
+      when: metadata_collection is defined and metadata_collection | default('false') | bool and (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata != "Complete")
 
     - block:
 
@@ -129,6 +115,6 @@
           hammerdb: "{{ workload.args }}"
         when: workload.name == "hammerdb" 
 
-      when: cr_state.resources[0].status.state is not defined or cr_state.resources[0].status.state != "Metadata Collecting"
-      
-    when: cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool
+      when: not metadata_collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete")
+
+    when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -27,6 +27,10 @@ spec:
     type: string
     description: The state of the benchmark
     JSONPath: .status.state
+  - name: Metadata State
+    type: string
+    description: The state of metadata collection
+    JSONPath: .status.metadata
   - name: UUID
     type: string
     JSONPath: .status.uuid

--- a/roles/backpack/tasks/main.yml
+++ b/roles/backpack/tasks/main.yml
@@ -5,7 +5,7 @@
     kind: Benchmark
     name: "{{ meta.name }}"
     namespace: "{{ operator_namespace }}"
-  register: cr_state
+  register: benchmark_state
 
 - k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
@@ -15,7 +15,8 @@
     status:
       state: "Metadata Collecting"
       complete: false
-  when: cr_state.resources[0].status.state is not defined
+      metadata: "Collecting"
+  when: benchmark_state.resources[0].status.state is not defined
 
 - name: Get benchmark state 
   k8s_facts:
@@ -23,7 +24,7 @@
     kind: Benchmark
     name: "{{ meta.name }}"
     namespace: "{{ operator_namespace }}"
-  register: cr_state
+  register: benchmark_state
 
 - name: Get DaemonSet state
   k8s_facts:
@@ -65,6 +66,7 @@
       status:
         state: "Metadata Collecting"
         complete: false
+        metadata: "Collecting"
     when: backpack_orig_gen != backpack_cur_gen
 
   - name: Get benchmark state
@@ -73,7 +75,7 @@
       kind: Benchmark
       name: "{{ meta.name }}"
       namespace: "{{ operator_namespace }}"
-    register: cr_state
+    register: benchmark_state
 
   - block:
   
@@ -95,6 +97,7 @@
           status:
             state: null
             complete: false
+            metadata: "Complete"
       
       - name: Get benchmark state
         k8s_facts:
@@ -102,10 +105,11 @@
           kind: Benchmark
           name: "{{ meta.name }}"
           namespace: "{{ operator_namespace }}"
-        register: cr_state
+        register: benchmark_state
 
       when: backpack_cur_gen == pods | json_query('resources[].metadata.labels."pod-template-generation"')|first and "ContainersNotReady" not in pods | json_query('resources[].status.conditions[].reason')
-
+    
     when: backpack_orig_gen == backpack_cur_gen
 
   when: "my_daemonset | json_query('resources[].status.desiredNumberScheduled') == my_daemonset | json_query('resources[].status.numberReady') and my_daemonset | json_query('resources[].status.numberReady') != 0 "
+

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -8,13 +8,14 @@ spec:
   selector:
     matchExpressions:
       - key: app
-        operator: NotIn
+        operator: In
         values:
         - backpack-{{ trunc_uuid }}
   template:
     metadata:
       labels:
         name: backpack-{{ trunc_uuid }}
+        app: backpack-{{ trunc_uuid }}
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -218,3 +218,28 @@ function error {
   kubectl -n my-ripsaw logs -l name=benchmark-operator -c ansible
   ERRORED=true
 }
+
+function wait_for_backpack() {
+  echo "Waiting for backpack to complete before starting benchmark test"
+  
+  uuid=$1
+  count=0
+  while [[ $count -lt 30 ]]
+  do
+    if [[ `kubectl -n my-ripsaw get daemonsets backpack-$uuid` ]]
+    then
+      desired=`kubectl -n my-ripsaw get daemonsets backpack-$uuid | grep -v NAME | awk '{print $2}'`
+      ready=`kubectl -n my-ripsaw get daemonsets backpack-$uuid | grep -v NAME | awk '{print $4}'`
+      if [[ $desired -eq $ready ]]
+      then
+        echo "Backpack complete. Starting benchmark"
+        count=30
+      fi
+    fi
+    if [[ $count -ne 30 ]]
+    then
+      sleep 5
+      count=$((count + 1))
+    fi
+  done
+}

--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -17,17 +17,13 @@ function finish {
 trap error ERR
 trap finish EXIT
 
-function functional_test_byowl {
+function functional_test_backpack {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_backpack.yaml
   uuid=$(get_uuid 20)
 
-  node_count=`kubectl get nodes | grep -v NAME | wc -l`
-  until [ `kubectl -n my-ripsaw get daemonsets backpack-$uuid | grep -v NAME | awk '{print $4}'` -eq $node_count ] ; do
-    sleep 5
-  done
-  echo $backpack_pod
+  wait_for_backpack $uuid
 
   for pod in `kubectl -n my-ripsaw get pods -l name=backpack-$uuid | grep -v NAME | awk '{print $1}'`
   do
@@ -44,4 +40,4 @@ function functional_test_byowl {
   echo "Backpack test: Success"
 }
 
-functional_test_byowl
+functional_test_backpack

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -22,6 +22,9 @@ function functional_test_byowl {
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   uuid=$(get_uuid 20)
+  
+  wait_for_backpack $uuid
+
   byowl_pod=$(get_pod "app=byowl-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=200s" "200s" $byowl_pod
   wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl-$uuid jobs --timeout=300s" "300s" $byowl_pod

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -4,6 +4,10 @@ metadata:
   name: byowl-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: byowl
     args:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+#  metadata_collection: true
   cleanup: false
   workload:
     name: "fio_distributed"

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: fs-drift
     args:

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -4,6 +4,10 @@ metadata:
   name: hammerdb
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: "hammerdb"
     args:

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: iperf3
     args:

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -4,6 +4,10 @@ metadata:
   name: pgbench-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: "pgbench"
     args:

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: smallfile
     args:

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: sysbench
     args:

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   cleanup: false
   workload:
     name: uperf

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -4,6 +4,10 @@ metadata:
   name: ycsb-mongo-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
   workload:
     name: ycsb
     args:

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -22,6 +22,9 @@ function functional_test_fio {
   apply_operator
   kubectl apply -f tests/test_crs/valid_fiod.yaml
   uuid=$(get_uuid 20)
+  
+  wait_for_backpack $uuid
+
   pod_count "app=fio-benchmark-$uuid" 2 300
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod --namespace my-ripsaw --timeout=200s" "200s" $fio_pod

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -15,9 +15,25 @@ function functional_test_fs_drift {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_fs_drift.yaml
-  sleep 15
   uuid=$(get_uuid 20)
-  fsdrift_pod=$(kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
+  
+  wait_for_backpack $uuid
+
+  count=0
+  while [[ $count -lt 24 ]]
+  do
+    if [[ `kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]
+    then
+      fsdrift_pod=$(kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
+      count=30
+    fi
+    if [[ $count -ne 30 ]]
+    then
+      sleep 5
+      count=$((count + 1))
+    fi
+  done
+
   echo fsdrift_pod $fs_drift_pod
   wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod \
     --namespace my-ripsaw --timeout=200s" "200s" $fsdrift_pod

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -24,6 +24,9 @@ function functional_test_hammerdb {
 	apply_operator
 	kubectl apply -f tests/test_crs/valid_hammerdb.yaml
 	uuid=$(get_uuid 20)
+
+        wait_for_backpack $uuid
+        
 	# Wait for the creator pod to initialize the DB
         #DISABLED
 	#hammerdb_creator_pod=$(get_pod "app=hammerdb_creator-$uuid" 300)

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -22,6 +22,9 @@ function functional_test_iperf {
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   uuid=$(get_uuid 20)
+
+  wait_for_backpack $uuid
+
   pod_count "app=iperf3-bench-server-$uuid" 1 300
   iperf_client_pod=$(get_pod "app=iperf3-bench-client-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=200s" "200s" $iperf_client_pod

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -73,6 +73,9 @@ EOF
   # deploy the test CR with the postgres pod IP
   sed s/host:/host:\ ${postgres_ip}/ tests/test_crs/valid_pgbench.yaml | kubectl apply -f -
   uuid=$(get_uuid 20)
+
+  wait_for_backpack $uuid
+
   pgbench_pod=$(get_pod "app=pgbench-client-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -22,6 +22,9 @@ function functional_test_sysbench {
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   uuid=$(get_uuid 20)
+
+  wait_for_backpack $uuid
+
   sysbench_pod=$(get_pod "app=sysbench-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=200s" "200s" $sysbench_pod
   # Higher timeout as it takes longer

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -22,8 +22,11 @@ function functional_test_uperf {
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf.yaml
   uuid=$(get_uuid 20)
-  pod_count "type=uperf-bench-server-$uuid" 1 300
-  uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 300)
+
+  wait_for_backpack $uuid
+
+  pod_count "type=uperf-bench-server-$uuid" 1 900
+  uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 900)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
   wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=500s" "500s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -22,6 +22,9 @@ function functional_test_uperf_serviceip {
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   uuid=$(get_uuid 20)
+
+  wait_for_backpack $uuid
+
   pod_count "type=uperf-bench-server-$uuid" 1 300
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -65,6 +65,9 @@ spec:
 EOF
   kubectl apply -f tests/test_crs/valid_ycsb-mongo.yaml
   uuid=$(get_uuid 20)
+
+  wait_for_backpack $uuid
+
   ycsb_load_pod=$(get_pod "name=ycsb-load-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$ycsb_load_pod -n my-ripsaw --timeout=60s" "60s" $ycsb_load_pod
   wait_for "kubectl wait --for=condition=Complete jobs -l name=ycsb-load-$uuid -n my-ripsaw --timeout=300s" "300s" $ycsb_load_pod

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,5 +3,5 @@
   group: ripsaw.cloudbulldozer.io
   kind: Benchmark
   playbook: /opt/ansible/playbook.yml
-  reconcilePeriod: 30s
+  reconcilePeriod: 3s
   manageStatus: false


### PR DESCRIPTION
**Updated 11/7**
    Adding:
    - Metadata State to benchmark
    - Reduced reconciliation time to 3s
    - We now only ever set the cr_state once in playbook.yml
    - Added wait_for_backpack function to ci tests
    - Resolved issue with backpack daemonset not allowing other pods to run
