### PR TITLE
Adding imagePullPolicy: Always to all benchmarks

### DIFF
--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -16,5 +16,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["{{ byowl.commands }}"]
         image: "{{ byowl.image }}"
+        imagePullPolicy: Always
         wait: true
       restartPolicy: OnFailure

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -17,6 +17,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["/usr/local/bin/uid_entrypoint; cd /hammer; ./hammerdbcli auto /creator/createdb.tcl"]
         image: "quay.io/cloud-bulldozer/hammerdb:latest"
+        imagePullPolicy: Always
         volumeMounts:
         - name: hammerdb-creator-volume
           mountPath: "/creator"

--- a/roles/hammerdb/templates/db_workload.yml
+++ b/roles/hammerdb/templates/db_workload.yml
@@ -19,6 +19,7 @@ spec:
         #args: ["/usr/local/bin/uid_entrypoint; cd /hammer; /opt/snafu/hammerdb-wrapper/hammerdb-wrapper.py"]
         image: "quay.io/cloud-bulldozer/hammerdb:latest"
         #image: "quay.io/mkarg/hammerdb:latest"
+        imagePullPolicy: Always
         wait: true
         volumeMounts:
         - name: hammerdb-workload-volume

--- a/roles/iperf3-bench/templates/client_store.yml.j2
+++ b/roles/iperf3-bench/templates/client_store.yml.j2
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
+        imagePullPolicy: Always
         wait: true
         command: ["/bin/sh", "-c"]
         args:

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -15,6 +15,7 @@ spec:
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/iperf3:latest"
+    imagePullPolicy: Always
     wait: true
     command: ["/bin/sh", "-c"]
     args:

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: benchmark
         image: "{{ pgb_base_image }}:{{ pgb_version }}"
+        imagePullPolicy: Always
         wait: true
         env:
           - name: PGPASSWORD

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -18,6 +18,7 @@ spec:
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/uperf:latest"
+    imagePullPolicy: Always
     wait: true
     command: ["/bin/sh","-c"]
     args: ["uperf -s -v -P 20000"]

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -38,6 +38,7 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/uperf:latest"
+        imagePullPolicy: Always
         wait: true
         command: ["/bin/sh", "-c"]
         args:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -7,7 +7,7 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-#  metadata_collection: true
+  metadata_collection: true
   cleanup: false
   workload:
     name: "fio_distributed"


### PR DESCRIPTION
To help avoid issues with using old images I have added imagePullPolicy: Always to the remaining benchmarks that did not have them.