### PR TITLE
so run_snafu.py can work in CI

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: aws-2009-09-10
   # where elastic search is running
   elasticsearch:
-    server: marquez.perf.lab.eng.rdu2.redhat.com
+    server: my.elasticsearch.server
     port: 9200
   workload:
     name: fs-drift

--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: aws-2009-09-10
   # where elastic search is running
   elasticsearch:
-    host: marquez.perf.lab.eng.rdu2.redhat.com
+    server: marquez.perf.lab.eng.rdu2.redhat.com
     port: 9200
   workload:
     name: fs-drift

--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -8,9 +8,9 @@ spec:
   # to separate this test run from everyone else's
   clustername: aws-2009-09-10
   # where elastic search is running
-  es_server: ec2-18-220-65-133.us-east-2.compute.amazonaws.com
-  es_port: 19020
-  es_index: ripsaw-fs-drift
+  elasticsearch:
+    host: marquez.perf.lab.eng.rdu2.redhat.com
+    port: 9200
   workload:
     name: fs-drift
     args:

--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   test_user: homer_simpson
   clustername: aws-2009-09-10
-  es_server: my.elasticsearch.server
-  es_port: 9020
-  es_index: ripsaw-smallfile
+  elasticsearch:
+    host: my.elasticsearch.server
+    port: 9020
   workload:
     name: smallfile
     args:

--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -7,7 +7,7 @@ spec:
   test_user: homer_simpson
   clustername: aws-2009-09-10
   elasticsearch:
-    host: my.elasticsearch.server
+    server: my.elasticsearch.server
     port: 9020
   workload:
     name: smallfile

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -25,17 +25,15 @@ spec:
           env:
           - name: uuid
             value: "{{ uuid }}"
-{% if es_server is defined %}
           - name: test_user
             value: "{{ test_user }}"
           - name: clustername
             value: "{{ clustername }}"
+{% if elasticsearch.host is defined %}
           - name: es
-            value: "{{ es_server }}"
+            value: "{{ elasticsearch.host }}"
           - name: es_port
-            value: "{{ es_port }}"
-          - name: es_index
-            value: "{{ es_index }}"
+            value: "{{ elasticsearch.port }}"
 {% endif %}
           args:
             - set -x;

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -29,9 +29,9 @@ spec:
             value: "{{ test_user }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch.host is defined %}
+{% if elasticsearch.server is defined %}
           - name: es
-            value: "{{ elasticsearch.host }}"
+            value: "{{ elasticsearch.server }}"
           - name: es_port
             value: "{{ elasticsearch.port }}"
 {% endif %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -34,6 +34,8 @@ spec:
             value: "{{ elasticsearch.server }}"
           - name: es_port
             value: "{{ elasticsearch.port }}"
+          - name: es_index
+            value: "{{ es_index }}"
 {% endif %}
           args:
             - set -x;

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -23,19 +23,17 @@ spec:
           workingDir: /opt/snafu
           wait: true
           env:
-{% if es_server is defined %}
           - name: uuid
             value: "{{ uuid }}"
           - name: test_user
             value: "{{ test_user }}"
           - name: clustername
             value: "{{ clustername }}"
+{% if elasticsearch.host is defined %}
           - name: es
-            value: "{{ es_server }}"
+            value: "{{ elasticsearch.host }}"
           - name: es_port
-            value: "{{ es_port }}"
-          - name: es_index
-            value: "{{ es_index }}"
+            value: "{{ elasticsearch.port }}"
 {% endif %}
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -34,6 +34,8 @@ spec:
             value: "{{ elasticsearch.server }}"
           - name: es_port
             value: "{{ elasticsearch.port }}"
+          - name: es_index
+            value: "{{ es_index }}"
 {% endif %}
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -29,9 +29,9 @@ spec:
             value: "{{ test_user }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch.host is defined %}
+{% if elasticsearch.server is defined %}
           - name: es
-            value: "{{ elasticsearch.host }}"
+            value: "{{ elasticsearch.server }}"
           - name: es_port
             value: "{{ elasticsearch.port }}"
 {% endif %}

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -9,8 +9,9 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    server: marquez.perf.lab.eng.rdu2.redhat.com
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
+  es_index: ripsaw-fs-drift
   metadata_collection: true
   workload:
     name: fs-drift

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -8,9 +8,9 @@ spec:
   # to separate this test run from everyone else's
   clustername: test_ci
   # where elastic search is running
-  es_server: marquez.perf.lab.eng.rdu2.redhat.com
-  es_port: 9200
-  es_index: ripsaw-fs-drift
+  elasticsearch:
+    host: marquez.perf.lab.eng.rdu2.redhat.com
+    port: 9200
   metadata_collection: true
   workload:
     name: fs-drift

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    host: marquez.perf.lab.eng.rdu2.redhat.com
+    server: marquez.perf.lab.eng.rdu2.redhat.com
     port: 9200
   metadata_collection: true
   workload:

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -4,9 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  elasticsearch:
-    server: "marquez.perf.lab.eng.rdu2.redhat.com"
-    port: 9200
+  test_user: homer_simpson
+  # to separate this test run from everyone else's
+  clustername: test_ci
+  # where elastic search is running
+  es_server: marquez.perf.lab.eng.rdu2.redhat.com
+  es_port: 9200
+  es_index: ripsaw-fs-drift
   metadata_collection: true
   workload:
     name: fs-drift

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    host: "marquez.perf.lab.eng.rdu2.redhat.com"
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
   metadata_collection: true
   workload:

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -4,9 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  elasticsearch:
-    server: "marquez.perf.lab.eng.rdu2.redhat.com"
-    port: 9200
+  test_user: homer_simpson
+  # to separate this test run from everyone else's
+  clustername: test_ci
+  # where elastic search is running
+  es_server: "marquez.perf.lab.eng.rdu2.redhat.com"
+  es_port: 9200
+  es_index: ripsaw-fs-drift
   metadata_collection: true
   workload:
     name: smallfile

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -8,9 +8,9 @@ spec:
   # to separate this test run from everyone else's
   clustername: test_ci
   # where elastic search is running
-  es_server: "marquez.perf.lab.eng.rdu2.redhat.com"
-  es_port: 9200
-  es_index: ripsaw-fs-drift
+  elasticsearch:
+    host: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
   metadata_collection: true
   workload:
     name: smallfile

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -11,6 +11,7 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
+  es_index: ripsaw-smallfile
   metadata_collection: true
   workload:
     name: smallfile


### PR DESCRIPTION
This makes the 2 CRs conform to the snafu README.md documentation for how to point to elastic search.