### PR TITLE
Pass number of clients and redis host to smallfile jobs

### DIFF
--- a/roles/smallfile-bench/tasks/main.yml
+++ b/roles/smallfile-bench/tasks/main.yml
@@ -7,7 +7,8 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- name: Update current state
+  k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -17,7 +18,7 @@
       complete: false
   when: resource_state.resources[0].status.state is not defined
 
-- name: Update current state
+- name: Get current state
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -37,6 +37,10 @@ spec:
           - name: es_index
             value: "{{ es_index }}"
 {% endif %}
+          - name: redis_host
+            value: "{{ bo.resources[0].status.podIP }}"
+          - name: clients
+            value: "{{ smallfile.clients }}"
           args:
             - python /tmp/smallfile/subscriber {{bo.resources[0].status.podIP}};
               export TMPDIR=/tmp


### PR DESCRIPTION
Required to fix https://github.com/cloud-bulldozer/snafu/issues/98
These variables are required to the smallfile snafu wrapper, so that this will be able to synchronize smallfile status using redis channel subscriptions