### PR TITLE
lengthen test to generate response time data to ES

### DIFF
--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -19,5 +19,5 @@ spec:
       clients: 1
       operation: ["create", "read", "append", "delete"]
       threads: 1
-      file_size: 64
-      files: 100
+      file_size: 0
+      files: 100000


### PR DESCRIPTION
must be longer than 1 second to insert into ripsaw-smallfile-rsptimes index
This fixes a problem noticed in [snafu PR 99](https://github.com/cloud-bulldozer/snafu/pull/99#issuecomment-563419259).
Please mark OK TO TEST and merge ASAP.