### PR TITLE
Add service selector to uperf svc jobs

### DIFF
--- a/roles/uperf-bench/templates/service.yml.j2
+++ b/roles/uperf-bench/templates/service.yml.j2
@@ -8,6 +8,8 @@ metadata:
     app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
     type: uperf-bench-server-{{ trunc_uuid }}
 spec:
+  selector:
+    type: uperf-bench-server-{{ trunc_uuid }}
   ports:
   - name: uperf
     port: 20000


### PR DESCRIPTION
Uperf service targeted benchmark is missing pod selector, this PR includes one based on the pod's type label.