### PR TITLE
Enable I/O tests to benchmark hostPath volumes

### DIFF
--- a/deploy/20_role.yaml
+++ b/deploy/20_role.yaml
@@ -67,3 +67,19 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - privileged
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/50_pod_security_policy.yml
+++ b/deploy/50_pod_security_policy.yml
@@ -1,0 +1,25 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -25,6 +25,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: fio-server
+{% if hostpath is defined %}
+        securityContext:
+          privileged: true
+{% endif %}
         image: "quay.io/cloud-bulldozer/fio:latest"
         imagePullPolicy: Always
         ports:
@@ -33,19 +37,26 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - "cd /tmp; fio --server"
-{% if fiod.storageclass is defined %}
+{% if fiod.storageclass is defined or hostpath is defined %}
         volumeMounts:
-        - name: ceph-volume
-          mountPath: "/mnt/pvc"
+        - name: data-volume
+          mountPath: "{{ fio_path }}"
 {% endif %}
       restartPolicy: Never
+      serviceAccountName: benchmark-operator
 {% if pin_server %}
       nodeSelector:
         kubernetes.io/hostname: '{{ pin_server }}'
 {% endif %}
 {% if fiod.storageclass is defined %}
       volumes:
-      - name: ceph-volume
+      - name: data-volume
         persistentVolumeClaim:
           claimName: claim-{{ item }}-{{ trunc_uuid }}
+{% elif hostpath is defined %}
+      volumes:
+      - name: data-volume
+        hostPath:
+          path: {{ hostpath }}
+          type: DirectoryOrCreate
 {% endif %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -15,6 +15,10 @@ spec:
       restartPolicy: Never
       containers:
         - name: benchmark-server
+{% if hostpath is defined %}
+          securityContext:
+            privileged: true
+{% endif %}
           image: quay.io/cloud-bulldozer/fs-drift:master
           # example of what to do when debugging image
           # image: quay.io/bengland2/fs-drift:latest
@@ -57,8 +61,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: "/tmp/fs-drift"
-{% if fs_drift.storageclass is defined %}
-            - name: storage-volume
+{% if fs_drift.storageclass is defined  or hostpath is defined %}
+            - name: data-volume
               mountPath: "{{ fs_drift_path }}"
 {% endif %}
       volumes:
@@ -67,9 +71,14 @@ spec:
             name: fs-drift-test-{{ trunc_uuid }}
             defaultmode: 0777
 {% if fs_drift.storageclass is defined %}
-        - name: storage-volume
+        - name: data-volume
           persistentVolumeClaim:
             claimName: "fs-drift-claim-{{ trunc_uuid }}-{{ item }}"
+{% elif hostpath is defined %}
+        - name: data-volume
+          hostPath:
+            path: {{ hostpath }}
+            type: DirectoryOrCreate
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -15,6 +15,10 @@ spec:
       restartPolicy: Never
       containers:
         - name: benchmark-server
+{% if hostpath is defined %}
+          securityContext:
+            privileged: true
+{% endif %}
           image: "quay.io/cloud-bulldozer/smallfile:master"
           # example of how to debug using your own workload image
           #image: "quay.io/bengland2/smallfile:master"
@@ -61,8 +65,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: "/tmp/smallfile"
-{% if smallfile.storageclass is defined %}
-            - name: ceph-volume
+{% if smallfile.storageclass is defined or hostpath is defined %}
+            - name: data-volume
               mountPath: "{{ smallfile_path }}"
 {% endif %}
       restartPolicy: Never
@@ -72,9 +76,14 @@ spec:
             name: smallfile-test-{{ trunc_uuid }}
             defaultmode: 0777
 {% if smallfile.storageclass is defined %}
-        - name: ceph-volume
+        - name: data-volume
           persistentVolumeClaim:
             claimName: "claim{{item}}-{{ trunc_uuid }}"
+{% elif hostpath is defined %}
+        - name: data-volume
+          hostPath:
+            path: {{ hostpath }}
+            type: DirectoryOrCreate
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -31,6 +31,7 @@ function populate_test_list {
 }
 
 function wait_clean {
+  kubectl delete benchmark --all -n my-ripsaw
   kubectl delete all --all -n my-ripsaw
   for i in {1..30}; do
     if [ `kubectl get pods --namespace my-ripsaw | grep bench | wc -l` -ge 1 ]; then
@@ -110,9 +111,7 @@ function pod_count () {
 function apply_operator {
   operator_requirements
   kubectl apply -f resources/operator.yaml
-  ripsaw_pod=$(get_pod 'name=benchmark-operator' 300)
-  kubectl wait --for=condition=Initialized "pods/$ripsaw_pod" --namespace my-ripsaw --timeout=60s
-  kubectl wait --for=condition=Ready "pods/$ripsaw_pod" --namespace my-ripsaw --timeout=300s
+  kubectl wait --for=condition=available "deployment/benchmark-operator" -n my-ripsaw --timeout=300s
 }
 
 function delete_operator {

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -1,0 +1,57 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  cleanup: false
+  hostpath: /mnt/vda1/fiod/
+  workload:
+    name: "fio_distributed"
+    args:
+      samples: 2
+      servers: 2
+      jobs:
+        - write
+        - read
+      bs:
+        - 4KiB
+        - 64KiB
+      numjobs:
+        - 1
+        - 2
+      iodepth: 2
+      read_runtime: 3
+      read_ramp_time: 1
+      filesize: 10MiB
+      log_sample_rate: 1000
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+  job_params:
+    - jobname_match: w
+      params:
+        - fsync_on_close=1
+        - create_on_open=1
+    - jobname_match: read
+      params:
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: rw
+      params:
+        - rwmixread=50
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: readwrite
+      params:
+        - rwmixread=50
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -1,0 +1,24 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  test_user: homer_simpson
+  # to separate this test run from everyone else's
+  clustername: test_ci
+  # where elastic search is running
+  es_index: ripsaw-fs-drift
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  hostpath: /mnt/vda1/fs_drift
+  workload:
+    name: fs-drift
+    args:
+      worker_pods: 1
+      threads: 5
+      max_file_size_kb: 4
+      max_files: 1000
+      duration: 5

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -1,0 +1,25 @@
+
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  test_user: homer_simpson
+  # to separate this test run from everyone else's
+  clustername: test_ci
+  # where elastic search is running
+  es_index: ripsaw-smallfile
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  hostpath: /mnt/vda1/smallfile
+  workload:
+    name: smallfile
+    args:
+      clients: 1
+      operation: ["create", "read", "append", "delete"]
+      threads: 1
+      file_size: 0
+      files: 100000

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -3,36 +3,28 @@ set -xeEo pipefail
 
 source tests/common.sh
 
-function finish {
-  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
-  then
-    error
-  fi
-
-  echo "Cleaning up Fio"
-  kubectl delete -f tests/test_crs/valid_fiod.yaml
-  delete_operator
-}
-
 trap error ERR
-trap finish EXIT
+trap wait_clean EXIT
 
 function functional_test_fio {
-  figlet $(basename $0)
   apply_operator
-  kubectl apply -f tests/test_crs/valid_fiod.yaml
+  test_name=$1
+  cr=$2
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-  
   wait_for_backpack $uuid
-
   pod_count "app=fio-benchmark-$uuid" 2 300
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod --namespace my-ripsaw --timeout=200s" "200s" $fio_pod
-  wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs --namespace my-ripsaw --timeout=500s" "500s" $fio_pod
-  sleep 30
+  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=200s" "200s" $fio_pod
+  wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs -n my-ripsaw --timeout=500s" "500s" $fio_pod
   # ensuring the run has actually happened
-  kubectl logs "$fio_pod" --namespace my-ripsaw | grep "fio has successfully finished sample"
-  echo "Fio distributed test: Success"
+  kubectl logs "$fio_pod" -n my-ripsaw
+  kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
+  echo "${test_name} test: Success"
+  wait_clean
 }
 
-functional_test_fio
+figlet $(basename $0)
+functional_test_fio "Fio distributed" tests/test_crs/valid_fiod.yaml
+functional_test_fio "Fio hostpath distributed" tests/test_crs/valid_fiod_hostpath.yaml

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -3,51 +3,38 @@ set -xeo pipefail
 
 source tests/common.sh
 
-function finish {
-  echo "Cleaning up fs-drift"
-  kubectl delete -f tests/test_crs/valid_fs_drift.yaml
-  delete_operator
-}
-
-trap finish EXIT
+trap error ERR
+trap wait_clean EXIT
 
 function functional_test_fs_drift {
-  figlet $(basename $0)
   apply_operator
-  kubectl apply -f tests/test_crs/valid_fs_drift.yaml
+  test_name=$1
+  cr=$2
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-  
   wait_for_backpack $uuid
-
   count=0
-  while [[ $count -lt 24 ]]
-  do
-    if [[ `kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]
-    then
+  while [[ $count -lt 24 ]]; do
+    if [[ `kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]; then
       fsdrift_pod=$(kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
       count=30
     fi
-    if [[ $count -ne 30 ]]
-    then
+    if [[ $count -ne 30 ]]; then
       sleep 5
       count=$((count + 1))
     fi
   done
-
   echo fsdrift_pod $fs_drift_pod
-  wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod \
-    --namespace my-ripsaw --timeout=200s" "200s" $fsdrift_pod
-  wait_for "kubectl wait --for=condition=complete -l app=fs-drift-benchmark-$uuid jobs \
-    --namespace my-ripsaw --timeout=100s" "200s" $fsdrift_pod
-  sleep 5
-  # ensuring the run has actually happened
-  kubectl logs "$fsdrift_pod" --namespace my-ripsaw | grep "RUN STATUS"
-  if [ $? = 0 ] ; then
-    echo "fs-drift test: Success" 
-  else 
-    echo fs-drift test FAILURE 
-    exit 1 
-  fi
+  wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod -n my-ripsaw --timeout=200s" "200s" $fsdrift_pod
+  wait_for "kubectl wait --for=condition=complete -l app=fs-drift-benchmark-$uuid jobs -n my-ripsaw --timeout=100s" "200s" $fsdrift_pod
+  # Print logs and check status
+  kubectl logs "$fsdrift_pod" -n my-ripsaw
+  kubectl logs "$fsdrift_pod" -n my-ripsaw | grep "RUN STATUS"
+  echo "${test_name} test: Success"
+  wait_clean
 }
 
-functional_test_fs_drift
+figlet $(basename $0)
+functional_test_fs_drift "fs-drift" tests/test_crs/valid_fs_drift.yaml
+functional_test_fs_drift "fs-drift hostpath" tests/test_crs/valid_fs_drift_hostpath.yaml

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -3,51 +3,39 @@ set -xeEo pipefail
 
 source tests/common.sh
 
-function finish {
-  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
-  then
-    error
-  fi
-
-  echo "Cleaning up Smallfile"
-  kubectl delete -f tests/test_crs/valid_smallfile.yaml
-  delete_operator
-}
-
 trap error ERR
-trap finish EXIT
+trap wait_clean EXIT
 
 function functional_test_smallfile {
-  figlet $(basename $0)
   apply_operator
-  kubectl apply -f tests/test_crs/valid_smallfile.yaml
+  test_name=$1
+  cr=$2
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-
   wait_for_backpack $uuid  
-
   count=0
-  while [[ $count -lt 24 ]]
-  do
-    if [[ `kubectl get pods -l app=smallfile-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]
-    then
+  while [[ $count -lt 24 ]]; do
+    if [[ `kubectl get pods -l app=smallfile-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]; then
       smallfile_pod=$(kubectl get pods -l app=smallfile-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client)
       count=30
     fi
-    if [[ $count -ne 30 ]]
-    then
+    if [[ $count -ne 30 ]]; then
       sleep 5
       count=$((count + 1))
     fi
   done
-  echo smallfile_pod $smallfile_pod
+  echo "smallfile_pod ${smallfile_pod}"
   wait_for "kubectl wait --for=condition=Initialized -l app=smallfile-benchmark-$uuid pods --namespace my-ripsaw --timeout=200s" "200s"
   wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark-$uuid jobs --namespace my-ripsaw --timeout=100s" "100s"
-  sleep 30
   # ensuring the run has actually happened
   for pod in ${smallfile_pod}; do
     kubectl logs ${pod} --namespace my-ripsaw | grep "RUN STATUS"
   done
-  echo "Smallfile test: Success"
+  echo "${test_name} test: Success"
+  wait_clean
 }
 
-functional_test_smallfile
+figlet $(basename $0)
+functional_test_smallfile "smallfile" tests/test_crs/valid_smallfile.yaml
+functional_test_smallfile "smallfile hostpath" tests/test_crs/valid_smallfile_hostpath.yaml


### PR DESCRIPTION
Doing I/O benchmarks directly on top of containers implies making those I/O operations on the container filesystem, usually OverlayFS. This PR enables some ripsaw benchmarks to perform those tests on hostPaths  devices in order to avoid the OverlayFS layer.
Accessing to hostPath volumes require running pod as privileged, so the role has been also granted usage to the hostaccess SCC