### PR TITLE
Changing image location to cloud-bulldozer

### DIFF
--- a/roles/hammerdb/templates/db_workload.yml.j2
+++ b/roles/hammerdb/templates/db_workload.yml.j2
@@ -13,8 +13,7 @@ spec:
     spec:
       containers:
       - name: hammerdb
-        #image: "quay.io/cloud-bulldozer/hammerdb:latest"
-        image: "quay.io/mkarg/hammerdb:latest"
+        image: "quay.io/cloud-bulldozer/hammerdb:latest"
         wait: true
         command: ["/bin/sh", "-c"]
         args: 


### PR DESCRIPTION
One of the hammer templates was still using @mkarg75 's quay repo. This updates it to use cloud-bulldozer.