### PR TITLE
Adding namespace deletion/creation to requirements

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -10,8 +10,6 @@ figlet $ci_test
 cd $ci_dir
 source tests/common.sh
 
-kubectl apply -f resources/namespace.yaml
-
 count=0
 start_time=`date`
 
@@ -55,4 +53,3 @@ do
   ((count++))
 done
 wait_clean
-kubectl delete -f resources/namespace.yaml

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -39,6 +39,7 @@ function wait_clean {
       break
     fi
   done
+  kubectl delete namespace my-ripsaw
 }
 
 # The argument is 'timeout in seconds'
@@ -142,6 +143,7 @@ function marketplace_cleanup {
 }
 
 function operator_requirements {
+  kubectl apply -f resources/namespace.yaml
   kubectl apply -f deploy
   kubectl apply -f resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 }


### PR DESCRIPTION
The namespace was not getting cleaned up during ci tests. This would sometimes lead to things being stuck in pending states. This will now delete the namespace in wait_clean and also ensure its created in the operator_requirements.