### PR TITLE
Add pod anti-affinity rules to IO jobs

### DIFF
--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -12,6 +12,18 @@ spec:
       labels:
         app: fs-drift-benchmark-{{ trunc_uuid }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - fs-drift-benchmark-{{ trunc_uuid }}
+              topologyKey: "kubernetes.io/hostname"
       restartPolicy: Never
       containers:
         - name: benchmark-server

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -12,6 +12,18 @@ spec:
       labels:
         app: smallfile-benchmark-{{ trunc_uuid }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - smallfile-benchmark-{{ trunc_uuid }}
+              topologyKey: "kubernetes.io/hostname"
       restartPolicy: Never
       containers:
         - name: benchmark-server


### PR DESCRIPTION
Ensure IO clients spread among different nodes