### PR TITLE
Support StatefulSet v1 spec in test_ycsb.sh wrapper

### DIFF
--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -40,7 +40,7 @@ spec:
    role: mongo
 EOF
 cat << EOF | kubectl apply -f -
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
  name: mongo
@@ -48,6 +48,9 @@ metadata:
 spec:
  serviceName: "mongo"
  replicas: 1
+ selector:
+   matchLabels:
+     role: mongo
  template:
    metadata:
      labels:


### PR DESCRIPTION
StatefulSet no longer tolerates the apps/v1beta1 API group.   It has been v1 since 1.9, so this change should be safe.