### PR TITLE
Updating CRD api to version v1

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,18 +1,17 @@
 ## Installation
-This guide uses minishift version v1.33.0+ as the local Kubernetes cluster
-and quay.io for the public registry. We also test on minikube version v0.35+.
+This guide uses minikube version v1.5.2+ as the local Kubernetes cluster
+and quay.io for the public registry. We also test on crc version v1.7.0+.
 `kubectl` is used but can be substituted with `oc`.
 
 ### Supported versions
-* [OKD](https://www.okd.io/)
-  * Experimental: 3.11
 * [OpenShift® Container Platform](https://www.openshift.com/products/container-platform/)
-  * Fully supported: 4.0
-  * Experimental: 3.11
+  * Fully supported: 4.3
 * [kubernetes](https://kubernetes.io/)
-  * Experimental: 1.11-1.13
+  * Fully supported: 1.16.2
 
-Note: Experimental tag refers to some workloads that might be functioning
+Note: 
+* Experimental tag refers to some workloads that might be functioning
+* To use versions of Openshift and kubernetes prior to 4.3 and 1.16.2 respectively, please use version 0.0.2 of ripsaw
 
 ### Requirements
 <!---

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -11,29 +11,78 @@ spec:
     plural: benchmarks
     singular: benchmark
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-  additionalPrinterColumns:
-  - name: Type
-    type: string
-    description: The type of test to perform
-    JSONPath: .spec.workload.name
-  - name: State
-    type: string
-    description: The state of the benchmark
-    JSONPath: .status.state
-  - name: Metadata State
-    type: string
-    description: The state of metadata collection
-    JSONPath: .status.metadata
-  - name: UUID
-    type: string
-    JSONPath: .status.uuid
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              elasticsearch:
+                type: object
+                properties:
+                  server:
+                    type: string
+                  port: 
+                    type: integer
+              workload:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+              job_params:
+                x-kubernetes-preserve-unknown-fields: true
+                type: array
+                items:
+                  type: object
+              metadata_collection:
+                type: boolean
+              metadata_privledged:
+                type: boolean
+              metadata_targeted:
+                type: boolean
+              cleanup:
+                type: boolean
+              test_user: 
+                type: string
+              clustername: 
+                type: string
+### I don't know if this one is needed but its in fs_drift
+              es_index: 
+                type: string 
+          status:
+            type: object
+            properties:
+              complete:
+                type: boolean
+              metadata:
+                type: string
+              state:
+                type: string
+              suuid:
+                type: string
+              uuid:
+                type: string
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The type of test to perform
+      jsonPath: .spec.workload.name
+    - name: State
+      type: string
+      description: The state of the benchmark
+      jsonPath: .status.state
+    - name: Metadata State
+      type: string
+      description: The state of metadata collection
+      jsonPath: .status.metadata
+    - name: UUID
+      type: string
+      jsonPath: .status.uuid
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    subresources:
+      status: {}

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -5,7 +5,7 @@ source tests/common.sh
 
 function initdb_pod {
 	echo "Setting up a MS-SQL DB Pod"
-	kubectl create -f tests/mssql.yaml
+	kubectl apply -f tests/mssql.yaml
         mssql_pod=$(get_pod "app=mssql" 300 "sql-server")
 	kubectl wait --for=condition=Ready "pods/$mssql_pod" --namespace sql-server --timeout=300s
 }

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -45,6 +45,9 @@ metadata:
   name: postgres
   namespace: my-ripsaw
 spec:
+  selector:
+    matchLabels:
+      app: postgres
   replicas: 1
   selector:
     matchLabels:

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -46,6 +46,9 @@ metadata:
  name: mongo
  namespace: my-ripsaw
 spec:
+ selector:
+   matchLabels:
+     role: mongo
  serviceName: "mongo"
  replicas: 1
  selector:


### PR DESCRIPTION
Updating the CRD api to v1. This will require changes to the crd file as well as changes to cr's using older api versions for kinds deployment and stateful sets.

Additional changes may need to be made on a benchmark to benchmark basis to account for the tighter restrictions around cr validation.