### PR TITLE
Adding a check to the namespace deletion

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -40,7 +40,9 @@ function wait_clean {
       break
     fi
   done
-  kubectl delete namespace my-ripsaw
+  if [[ `kubectl get namespace my-ripsaw` ]]; then
+    kubectl delete namespace my-ripsaw
+  fi
 }
 
 # The argument is 'timeout in seconds'


### PR DESCRIPTION
There are times that we run a wait_clean after a wait_clean. When the namespace is already deleted this can throw an error. This adds a check for the existence of the namespace first.