### PR TITLE
Changing trap wait_clean to trap finish to fix snafu ci error

### DIFF
--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -3,8 +3,18 @@ set -xeEo pipefail
 
 source tests/common.sh
 
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up fio"
+  wait_clean
+}
+
 trap error ERR
-trap wait_clean EXIT
+trap finish EXIT
 
 function functional_test_fio {
   apply_operator
@@ -22,9 +32,9 @@ function functional_test_fio {
   kubectl logs "$fio_pod" -n my-ripsaw
   kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
   echo "${test_name} test: Success"
-  wait_clean
 }
 
 figlet $(basename $0)
 functional_test_fio "Fio distributed" tests/test_crs/valid_fiod.yaml
+wait_clean
 functional_test_fio "Fio hostpath distributed" tests/test_crs/valid_fiod_hostpath.yaml

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -3,8 +3,19 @@ set -xeo pipefail
 
 source tests/common.sh
 
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up fs_drift"
+  wait_clean
+}
+
+
 trap error ERR
-trap wait_clean EXIT
+trap finish EXIT
 
 function functional_test_fs_drift {
   apply_operator
@@ -32,9 +43,9 @@ function functional_test_fs_drift {
   kubectl logs "$fsdrift_pod" -n my-ripsaw
   kubectl logs "$fsdrift_pod" -n my-ripsaw | grep "RUN STATUS"
   echo "${test_name} test: Success"
-  wait_clean
 }
 
 figlet $(basename $0)
 functional_test_fs_drift "fs-drift" tests/test_crs/valid_fs_drift.yaml
+wait_clean
 functional_test_fs_drift "fs-drift hostpath" tests/test_crs/valid_fs_drift_hostpath.yaml

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -3,8 +3,19 @@ set -xeEo pipefail
 
 source tests/common.sh
 
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up smallfile"
+  wait_clean
+}
+
+
 trap error ERR
-trap wait_clean EXIT
+trap finish EXIT
 
 function functional_test_smallfile {
   apply_operator
@@ -33,9 +44,9 @@ function functional_test_smallfile {
     kubectl logs ${pod} --namespace my-ripsaw | grep "RUN STATUS"
   done
   echo "${test_name} test: Success"
-  wait_clean
 }
 
 figlet $(basename $0)
 functional_test_smallfile "smallfile" tests/test_crs/valid_smallfile.yaml
+wait_clean
 functional_test_smallfile "smallfile hostpath" tests/test_crs/valid_smallfile_hostpath.yaml


### PR DESCRIPTION
Snafu ci expects there to be a trap finish function that it can remove to allow the existing pods to run longer so it can get the uuid from them.