### PR TITLE
Backpack will now properly fail the ci test if it does not launch

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -240,13 +240,16 @@ function wait_for_backpack() {
       if [[ $desired -eq $ready ]]
       then
         echo "Backpack complete. Starting benchmark"
-        count=$max_count
+        break
       fi
     fi
+    count=$((count + 1))
     if [[ $count -ne $max_count ]]
     then
       sleep 5
-      count=$((count + 1))
+    else
+      echo "Backpack failed to complete. Exiting"
+      exit 1
     fi
   done
 }


### PR DESCRIPTION
Previously if backpack failed to launch during a ci test it would continue anyway. This will now have it fail and exit properly.