### PR TITLE
Add continue/abort functionality if a failure occurs

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -36,6 +36,8 @@ spec:
       nthrs:
         - 1
       runtime: 30
+      continue_on_failure: "true"
+      redis_collection: "true"
 ```
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
@@ -58,7 +60,11 @@ $ oc adm policy add-scc-to-user privileged -z benchmark-operator
 
 `multus[1]` Configure our pods to use multus.
 
-`samples` how many times to run the tests. For example
+`samples` how many times to run the tests. For example.
+
+`continue_on_failure` If a failure occurs,  a `"true"` will continue on with the next test and a `"false"` will abort the test.
+
+`redis_collection` If `"true"`, the redis backend will collect the status code of each test. This can be set to `"false"` if this functionality is not required.
 
 [1] https://github.com/intel/multus-cni/tree/master/examples
 
@@ -75,6 +81,8 @@ $ oc adm policy add-scc-to-user privileged -z benchmark-operator
       nthrs:
         - 1
       runtime: 30
+      continue_on_failure: "true"
+      redis_collection: "true"
 ```
 
 Will run `stream` w/ `tcp` and message size `1024` three times and
@@ -257,6 +265,8 @@ spec:
       nthrs:
         - 1
       runtime: 30
+      continue_on_failure: "true"
+      redis_collection: "true"
 ```
 
 The new fields :

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -32,3 +32,5 @@ spec:
       nthrs:
         - 1
       runtime: 30
+      continue_on_failure: "true"
+      redis_collection: "true"

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -72,6 +72,9 @@ spec:
              export clustername={{clustername}};
              export hostnet={{uperf.hostnetwork}};
              export ips=$(hostname -I);
+             export bo_ip={{bo.resources[0].status.podIP}};
+             export redis_port={{bo.resources[0].spec.containers[2].ports[0].containerPort}};
+             export redis_collection={{uperf.redis_collection}};
              while true; do
                if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true' ]]; then
 {% for test in uperf.test_types %}
@@ -81,6 +84,15 @@ spec:
                  cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}};
                  for i in `seq 1 {{uperf.samples}}`; do
                    python /opt/snafu/uperf-wrapper/uperf-wrapper.py -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}} -r $i --resourcetype {{resource_kind}};
+                   if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} hget uperf-test {{uuid}}-uperf-{{test}}-{{proto}}-{{size}}-{{nthr}}) =~ '1' ]]; then
+                     if [[ {{uperf.continue_on_failure}} =~ 'true' ]]; then
+                       echo Workload {{uuid}} failed with parameters {{test}}-{{proto}}-{{size}}-{{nthr}}. Continuing with the next test..;  
+                       break;
+                     else
+                       echo Workload {{uuid}} failed with parameters {{test}}-{{proto}}-{{size}}-{{nthr}}. Aborting the test..;
+                       exit;
+                     fi;
+                   fi;
                  done;
 {% endfor %}
 {% endfor %}
@@ -104,3 +116,5 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ uperf.pin_client }}'
 {% endif %}
+
+


### PR DESCRIPTION
@jtaleric @aakarshg 
If a failure occurs, this commit will give us the ability to toggle between continuing with the pending tests or aborting them. We can also toggle between collecting/not_collecting the status code from redis. This PR is in conjunction with snafu PR 136 (https://github.com/cloud-bulldozer/snafu/pull/136)