### PR TITLE
Adding option to run backpack as an initcontainer

### DIFF
--- a/docs/ycsb.md
+++ b/docs/ycsb.md
@@ -66,3 +66,5 @@ Once done creating/editing the resource file, you can run it by:
 # kubectl apply -f resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml # if edited the original one
 # kubectl apply -f <path_to_file> # if created a new cr file
 ```
+
+*NOTE: Please note that if using metadata collection, ycsb does not currently work with the targeted init container method described in the metadata docs*

--- a/playbook.yml
+++ b/playbook.yml
@@ -43,6 +43,16 @@
       
       - include_role:
           name: backpack
+        when: not metadata_targeted | default('true') | bool
+
+      - k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            metadata: "Collecting"
+        when: metadata_targeted | default('true') | bool and not cr_state.resources[0].status.state is defined
     
       when: metadata_collection is defined and metadata_collection | default('false') | bool and (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata != "Complete")
 
@@ -115,6 +125,6 @@
           hammerdb: "{{ workload.args }}"
         when: workload.name == "hammerdb" 
 
-      when: not metadata_collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete")
-
+      when: not metadata_collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete") or metadata_targeted | default('true') | bool
+    
     when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -24,7 +24,7 @@ spec:
       - name: backpack
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} ; sleep infinity"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name; sleep infinity"]
         imagePullPolicy: Always
         wait: true
         securityContext:
@@ -37,5 +37,14 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 120
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
       serviceAccountName: {{ metadata_sa | default('default') }}
       terminationGracePeriodSeconds: 30

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -19,3 +19,24 @@ spec:
         imagePullPolicy: Always
         wait: true
       restartPolicy: OnFailure
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/fio-distributed/tasks/main.yml
+++ b/roles/fio-distributed/tasks/main.yml
@@ -95,7 +95,7 @@
       status:
         state: StartingClient
         complete: false
-    when : "fiod.servers == (server_pods | json_query('resources[].status.podIP')|length)"
+    when : "fiod.servers == (server_pods | json_query('resources[].status.podIP')|length) and fiod.servers == (server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length)"
 
   when: resource_state.resources[0].status.state == "StartingServers"
 

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -61,3 +61,24 @@ spec:
           name: "fio-hosts-{{ trunc_uuid }}"
           defaultMode: 0777
       restartPolicy: Never
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -60,3 +60,24 @@ spec:
           path: {{ hostpath }}
           type: DirectoryOrCreate
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+{% endif %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -94,3 +94,24 @@ spec:
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+{% endif %}

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -28,3 +28,24 @@ spec:
           name: "{{ meta.name }}-creator-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/hammerdb/templates/db_workload.yml.j2
+++ b/roles/hammerdb/templates/db_workload.yml.j2
@@ -50,3 +50,24 @@ spec:
           name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/iperf3-bench/tasks/main.yml
+++ b/roles/iperf3-bench/tasks/main.yml
@@ -32,6 +32,19 @@
       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     with_sequence: start=1 count={{ iperf3.pairs }}
 
+  - name: Update state to Starting Server
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Server"
+
+  when: resource_state.resources[0].status.state == "Starting"
+
+- block:
+
   - name: Wait for pods to be running....
     k8s_facts:
       kind: Pod
@@ -40,15 +53,47 @@
       label_selectors:
         - app = iperf3-bench-server-{{ trunc_uuid }}
     register: server_pods
-    until: "iperf3.pairs == (server_pods | json_query('resources[].status.podIP')|length)"
-    retries: 40
-    delay: 10
+
+  - name: Update state to Starting Clients
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Clients"
+    when: "iperf3.pairs == (server_pods | json_query('resources[].status.podIP')|length) and (server_pods | json_query('resources[].status.phase') is defined and iperf3.pairs == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length)"
+
+  when: resource_state.resources[0].status.state == "Starting Server"
+
+- block:
+
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = iperf3-bench-server-{{ trunc_uuid }}
+    register: server_pods
 
   - name: Start Client(s)
     k8s:
       definition: "{{ lookup('template', 'client.yml.j2') | from_yaml }}"
     with_items: "{{ server_pods.resources }}"
-    when: server_pods.resources|length > 0
+
+  - name: Update state to Waiting for Clients
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Waiting for Clients"  
+
+  when: resource_state.resources[0].status.state == "Starting Clients"
+
+- block:
 
   - name: Wait for pods to be running....
     k8s_facts:
@@ -69,7 +114,7 @@
         complete: false
     when: client_pods.resources|length > 0
 
-  when: ( iperf3.pairs > 0 ) and resource_state.resources[0].status.state == "Starting"
+  when: ( iperf3.pairs > 0 ) and resource_state.resources[0].status.state == "Waiting for Clients"
 
 - block:
   - name: Waiting for Jobs to complete....

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -31,3 +31,24 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ iperf3.pin_client }}'
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -25,3 +25,24 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: '{{ iperf3.pin_server }}'
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+  initContainers:
+  - name: backpack-{{ trunc_uuid }}
+    image: quay.io/cloud-bulldozer/backpack:latest
+    command: ["/bin/sh", "-c"]
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+    imagePullPolicy: Always
+    wait: true
+    securityContext:
+      privileged: {{ metadata_privileged | default(false) | bool }}
+    env:
+      - name: my_node_name
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: my_pod_name
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+  serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -73,3 +73,24 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: '{{ item.1.pin_node }}'
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -99,3 +99,24 @@ spec:
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+{% endif %}

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -28,3 +28,24 @@ spec:
           name: "sysbench-config-{{ trunc_uuid }}"
           defaultMode: 0777
       restartPolicy: OnFailure
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/uperf-bench/tasks/main.yml
+++ b/roles/uperf-bench/tasks/main.yml
@@ -26,77 +26,149 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
+- name: Capture operator information
+  k8s_facts:
+    kind: Pod
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - name = benchmark-operator
+  register: bo
+
 - block:
-  - name: Capture operator information
+  
+  - name: Create service for server pods
+    k8s:
+      definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
+    with_sequence: start=0 count={{ uperf.pair }}
+    when: uperf.serviceip
+
+  - name: Start Server(s)
+    k8s:
+      definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
+    register: servers
+    with_sequence: start=0 count={{ uperf.pair }}
+
+  - name: Wait for pods to be running....
     k8s_facts:
       kind: Pod
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - name = benchmark-operator
-    register: bo
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
 
-  - block:
-    - name: Create service for server pods
-      k8s:
-        definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
-      with_sequence: start=0 count={{ uperf.pair }}
-      when: uperf.serviceip
+  - name: Update resource state
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Servers"
 
-    - name: Start Server(s)
-      k8s:
-        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
-      register: servers
-      with_sequence: start=0 count={{ uperf.pair }}
+  when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
 
-    - name: Wait for pods to be running....
-      k8s_facts:
-        kind: Pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_pods
-      until: "'Running' in (server_pods | json_query('resources[].status.phase'))"
-      retries: 100
-      delay: 10
+- block:
 
-    - name: Capture ServiceIP
-      k8s_facts:
-        kind: Service
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: serviceip
-      when: uperf.serviceip
-    when: resource_kind == "pod"
+  - name: Start Server(s)
+    k8s:
+      definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
+    register: servers
+    with_sequence: start=0 count={{ uperf.pair }}
 
-  - block:
+  - name: Wait for vms to be running....
+    k8s_facts:
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_vms
+  
+  - name: Update resource state
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Servers"
 
-    - name: Start Server(s)
-      k8s:
-        definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
-      register: servers
-      with_sequence: start=0 count={{ uperf.pair }}
+  when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
 
-    - name: Wait for vms to be running....
-      k8s_facts:
-        kind: VirtualMachineInstance
-        api_version: kubevirt.io/v1alpha3
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_vms
-      until: "uperf.pair  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
-      retries: 100
-      delay: 15
+- block:
 
-    - name: blocking client from running uperf
-      command: "redis-cli set {{ trunc_uuid }} false"
-      with_items: "{{ server_vms.resources }}"
-    when: resource_kind == "vm" and uperf.pair|int == 1
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
+    
+  - name: Update resource state
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Clients"
+    when: "uperf.pair == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
 
+  - name: Capture ServiceIP
+    k8s_facts:
+      kind: Service
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: serviceip
+    when: "uperf.serviceip and uperf.pair == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+
+  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
+
+- block:
+  
+  - name: Wait for vms to be running....
+    k8s_facts:
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_vms
+
+  - name: Update resource state
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Clients"
+    when: "uperf.pair == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and uperf.pair  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
+  - name: blocking client from running uperf
+    command: "redis-cli set {{ trunc_uuid }} false"
+    with_items: "{{ server_vms.resources }}"
+    when: "uperf.pair == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and uperf.pair  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
+  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" and uperf.pair|int == 1
+
+- block:
+
+  - name: Get pod info
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
+  
   - name: Generate uperf xml files
     k8s:
       definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
@@ -113,9 +185,21 @@
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
       with_items: "{{ serviceip.resources }}"
       when: uperf.serviceip and serviceip.resources|length > 0
+
     when: resource_kind == "pod"
 
   - block:
+
+    - name: Wait for vms to be running....
+      k8s_facts:
+        kind: VirtualMachineInstance
+        api_version: kubevirt.io/v1alpha3
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - type = uperf-bench-server-{{ trunc_uuid }}
+      register: server_vms
+
+
     - name: Generate uperf test files
       k8s:
         definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
@@ -126,23 +210,23 @@
         definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
       with_items: "{{ server_vms.resources }}"
       when: server_vms.resources|length > 0
-    when: resource_kind == "vm"
 
+    when: resource_kind == "vm"
+  
   - k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
-        state: Starting
-        complete: false
+        state: Waiting for Clients
 
-  when: ( uperf.pair > 0 ) and (resource_state.resources[0].status.state == "Building" )
+  when: resource_state.resources[0].status.state == "Starting Clients"
 
 - block:
 
   - block:
-    - name: Check if all clients are up
+    - name: Get client pod status
       k8s_facts:
         kind: Pod
         api_version: v1
@@ -151,26 +235,24 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_pods
 
-    - name: Signal workload
-      command: "redis-cli set start true"
-      when: "uperf.pair  == (client_pods | json_query('resources[].status.podIP')|length)"
-
-    - k8s_status:
+    - name: Update resource state
+      k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
-          state: Running
-          complete: false
-      when: "uperf.pair  == (client_pods | json_query('resources[].status.podIP')|length)"
+          state: Clients Running
+      when: "uperf.pair == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and uperf.pair  == (client_pods | json_query('resources[].status.podIP')|length)"
+    
     when: resource_kind == "pod"
 
   - block:
+    
     - name: set complete to false
       command: "redis-cli set complete false"
 
-    - name: Check if all clients are up
+    - name: Get client vm status
       k8s_facts:
         kind: VirtualMachineInstance
         api_version: kubevirt.io/v1alpha3
@@ -179,21 +261,35 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_vms
 
-    - name: Signal workload
-      command: "redis-cli set start true"
-      when: "uperf.pair  == (client_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
-
-    - k8s_status:
+    - name: Update resource state
+      k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
-          state: Running
-          complete: false
-      when: "uperf.pair  == (client_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+          state: Clients Running
+      when: "uperf.pair == client_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and uperf.pair  == (client_vm | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
     when: resource_kind == "vm"
-  when: resource_state.resources[0].status.state == "Starting"
+
+  when: resource_state.resources[0].status.state == "Waiting for Clients"
+
+- block:
+
+  - name: Signal workload
+    command: "redis-cli set start true"
+
+  - name: Update resource state
+    k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Running"
+
+  when: resource_state.resources[0].status.state == "Clients Running"
 
 - block:
   - block:

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -33,3 +33,24 @@ spec:
     - name: net.ipv4.ip_local_port_range
       value: 20000 20011
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+  initContainers:
+  - name: backpack-{{ trunc_uuid }}
+    image: quay.io/cloud-bulldozer/backpack:latest
+    command: ["/bin/sh", "-c"]
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+    imagePullPolicy: Always
+    wait: true
+    securityContext:
+      privileged: {{ metadata_privileged | default(false) | bool }}
+    env:
+      - name: my_node_name
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: my_pod_name
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+  serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -104,3 +104,24 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ uperf.pin_client }}'
 {% endif %}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: quay.io/cloud-bulldozer/backpack:latest
+        command: ["/bin/sh", "-c"]
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+        imagePullPolicy: Always
+        wait: true
+        securityContext:
+          privileged: {{ metadata_privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata_sa | default('default') }}
+{% endif %}

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -23,10 +23,8 @@ function functional_test_byowl {
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   uuid=$(get_uuid 20)
   
-  wait_for_backpack $uuid
-
   byowl_pod=$(get_pod "app=byowl-$uuid" 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=200s" "200s" $byowl_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=500s" "500s" $byowl_pod
   wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl-$uuid jobs --timeout=300s" "300s" $byowl_pod
   kubectl -n my-ripsaw logs "$byowl_pod" | grep "Test"
   echo "BYOWL test: Success"

--- a/tests/test_crs/valid_backpack.yaml
+++ b/tests/test_crs/valid_backpack.yaml
@@ -8,6 +8,7 @@ spec:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
   metadata_collection: true
+  metadata_targeted: false
   workload:
     name: byowl
     args:

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -8,6 +8,7 @@ spec:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
   metadata_collection: true
+  metadata_targeted: false
   workload:
     name: ycsb
     args:

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -23,10 +23,10 @@ function functional_test_fio {
   echo "Performing: ${test_name}"
   kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-  wait_for_backpack $uuid
-  pod_count "app=fio-benchmark-$uuid" 2 300
+  pod_count "app=fio-benchmark-$uuid" 2 300  
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=fio-benchmark-$uuid pods --timeout=300s" "300s"
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=200s" "200s" $fio_pod
+  wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=500s" "500s" $fio_pod
   wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs -n my-ripsaw --timeout=500s" "500s" $fio_pod
   # ensuring the run has actually happened
   kubectl logs "$fio_pod" -n my-ripsaw

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -24,7 +24,6 @@ function functional_test_fs_drift {
   echo "Performing: ${test_name}"
   kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-  wait_for_backpack $uuid
   count=0
   while [[ $count -lt 24 ]]; do
     if [[ `kubectl get pods -l app=fs-drift-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]; then
@@ -37,7 +36,7 @@ function functional_test_fs_drift {
     fi
   done
   echo fsdrift_pod $fs_drift_pod
-  wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod -n my-ripsaw --timeout=200s" "200s" $fsdrift_pod
+  wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod -n my-ripsaw --timeout=500s" "500s" $fsdrift_pod
   wait_for "kubectl wait --for=condition=complete -l app=fs-drift-benchmark-$uuid jobs -n my-ripsaw --timeout=100s" "200s" $fsdrift_pod
   # Print logs and check status
   kubectl logs "$fsdrift_pod" -n my-ripsaw

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -25,8 +25,6 @@ function functional_test_hammerdb {
 	kubectl apply -f tests/test_crs/valid_hammerdb.yaml
 	uuid=$(get_uuid 20)
 
-        wait_for_backpack $uuid
-        
 	# Wait for the creator pod to initialize the DB
         #DISABLED
 	#hammerdb_creator_pod=$(get_pod "app=hammerdb_creator-$uuid" 300)
@@ -34,9 +32,8 @@ function functional_test_hammerdb {
 	#kubectl wait --for=condition=complete -l app=hammerdb_creator-$uuid --namespace my-ripsaw jobs --timeout=600s
 	# Wait for the workload pod to run the actual workload
 	hammerdb_workload_pod=$(get_pod "app=hammerdb_workload-$uuid" 300)
-	kubectl wait --for=condition=Initialized "pods/$hammerdb_workload_pod" --namespace my-ripsaw --timeout=100s
+	kubectl wait --for=condition=Initialized "pods/$hammerdb_workload_pod" --namespace my-ripsaw --timeout=400s
 	kubectl wait --for=condition=complete -l app=hammerdb_workload-$uuid --namespace my-ripsaw jobs --timeout=500s
-	#kubectl logs "$hammerdb_workload_pod" --namespace my-ripsaw | grep "SEQUENCE COMPLETE"
 	kubectl logs "$hammerdb_workload_pod" --namespace my-ripsaw | grep "Timestamp"
 	echo "Hammerdb test: Success"
 }

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -23,11 +23,10 @@ function functional_test_iperf {
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   uuid=$(get_uuid 20)
 
-  wait_for_backpack $uuid
-
-  pod_count "app=iperf3-bench-server-$uuid" 1 300
+  iperf_server_pod=$(get_pod "app=iperf3-bench-server-$uuid" 300)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=iperf3-bench-server-$uuid pods --timeout=300s" "300s" $iperf_server_pod
   iperf_client_pod=$(get_pod "app=iperf3-bench-client-$uuid" 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=200s" "200s" $iperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$iperf_client_pod --timeout=500s" "500s" $iperf_client_pod
   wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=iperf3-bench-client-$uuid jobs --timeout=100s" "100s" $iperf_client_pod
   sleep 5
   # ensuring that iperf actually ran and we can access metrics

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -77,10 +77,8 @@ EOF
   sed s/host:/host:\ ${postgres_ip}/ tests/test_crs/valid_pgbench.yaml | kubectl apply -f -
   uuid=$(get_uuid 20)
 
-  wait_for_backpack $uuid
-
   pgbench_pod=$(get_pod "app=pgbench-client-$uuid" 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
+  wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=360s" "360s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client-$uuid -n my-ripsaw --timeout=300s" "300s" $pgbench_pod
   kubectl logs -n my-ripsaw $pgbench_pod | grep 'tps ='

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -24,7 +24,6 @@ function functional_test_smallfile {
   echo "Performing: ${test_name}"
   kubectl apply -f ${cr}
   uuid=$(get_uuid 20)
-  wait_for_backpack $uuid  
   count=0
   while [[ $count -lt 24 ]]; do
     if [[ `kubectl get pods -l app=smallfile-benchmark-$uuid --namespace my-ripsaw -o name | cut -d/ -f2 | grep client` ]]; then
@@ -37,7 +36,7 @@ function functional_test_smallfile {
     fi
   done
   echo "smallfile_pod ${smallfile_pod}"
-  wait_for "kubectl wait --for=condition=Initialized -l app=smallfile-benchmark-$uuid pods --namespace my-ripsaw --timeout=200s" "200s"
+  wait_for "kubectl wait --for=condition=Initialized -l app=smallfile-benchmark-$uuid pods --namespace my-ripsaw --timeout=500s" "500s"
   wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark-$uuid jobs --namespace my-ripsaw --timeout=100s" "100s"
   # ensuring the run has actually happened
   for pod in ${smallfile_pod}; do

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -23,10 +23,8 @@ function functional_test_sysbench {
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   uuid=$(get_uuid 20)
 
-  wait_for_backpack $uuid
-
   sysbench_pod=$(get_pod "app=sysbench-$uuid" 300)
-  wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=200s" "200s" $sysbench_pod
+  wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=500s" "500s" $sysbench_pod
   # Higher timeout as it takes longer
   wait_for "kubectl wait --for=condition=complete -l app=sysbench-$uuid --namespace my-ripsaw jobs" "300s" $sysbench_pod
   # sleep isn't needed as the sysbench is kind: job so once it's complete we can access logs

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -23,11 +23,12 @@ function functional_test_uperf {
   kubectl apply -f tests/test_crs/valid_uperf.yaml
   uuid=$(get_uuid 20)
 
-  wait_for_backpack $uuid
-
   pod_count "type=uperf-bench-server-$uuid" 1 900
+
+  uperf_server_pod=$(get_pod "app=uperf-bench-server-0-$uuid" 300)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=uperf-bench-server-0-$uuid pods --timeout=300s" "300s" $uperf_server_pod
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 900)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=500s" "500s" $uperf_client_pod
   wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=500s" "500s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -23,11 +23,9 @@ function functional_test_uperf_serviceip {
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   uuid=$(get_uuid 20)
 
-  wait_for_backpack $uuid
-
   pod_count "type=uperf-bench-server-$uuid" 1 300
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=200s" "200s" $uperf_client_pod
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$uperf_client_pod --timeout=500s" "500s" $uperf_client_pod
   wait_for "kubectl -n my-ripsaw wait --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=300s" "300s" $uperf_client_pod
   #check_log $uperf_client_pod "Success"
   # This is for the operator playbook to finish running


### PR DESCRIPTION
This PR adds the default ability to run backpack as init containers instead of as a daemon set. 

There are a few notable differences between the DaemonSet and targeted options:

- First, and most important, the DaemonSet will run on ALL nodes of the cluster.
This means that if you have 200 nodes it will collect data from all the nodes
even if your relevant pod(s) are only running on a subset of nodes. You will end
up with more data than you need and slow down the start of your workload.

- If running targeted and with a service account (more on that below) the
entire workload will run as that service account. That is because service accounts
are done at a level above the container definition and can only be applied once.

- When run as a daemonset the backpack pods will not complete/terminate 
until you delete your benchmark. This is done to allow additional collections to 
be done as an ad-hoc basis as well.

- When running as a targeted init container the benchmark metadata status will be
set to "Collecting" however it will never be marked as completed as that would require
additional logic in the workloads which is out of scope.

- Finally, running as a targeted init container requires no additions to the workload
template. This may be preferable in certain situations.


Additionally, I have only added the backpack collection to workload/client template files. This may need adjustment. Also, as ycsb does not have a container template I enabled the classic backpack style for its testing.