### PR TITLE
handle case where old pods are still being terminated

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -76,8 +76,8 @@ function get_pod () {
   pod_name="False"
   until [ $pod_name != "False" ] ; do
     sleep $sleep_time
-    pod_name=$(kubectl get pods -l $1 --namespace ${3:-my-ripsaw} -o name | cut -d/ -f2)
-    if [ -z $pod_name ]; then
+    pod_name="$(kubectl get pods -l $1 --namespace ${3:-my-ripsaw} -o name | grep -vi Terminating | cut -d/ -f2)"
+    if [ -z "$pod_name" ]; then
       pod_name="False"
     fi
     counter=$(( counter+1 ))


### PR DESCRIPTION
for issue #228 
filter out pods in Terminating state
-z test should have quoted string as argument
so a list of > 1 pod will not cause syntax error

tested with fs-drift and smallfile, but how will CI react?   
Seemed like it made 2 passes when only 1 should have been necessary.