### PR TITLE
add continue/abort functionality in case of a failed test

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -47,6 +47,13 @@
       when: metadata_collection is defined and metadata_collection | default('false') | bool and (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata != "Complete")
 
     - block:
+      - include_role:
+          name: redis-collection
+        vars:
+          uperf: "{{ workload.args }}"
+      when: redis_collection is defined
+
+    - block:
 
       - include_role:
           name: "uperf-bench"
@@ -113,7 +120,7 @@
           name: "hammerdb"
         vars:
           hammerdb: "{{ workload.args }}"
-        when: workload.name == "hammerdb" 
+        when: workload.name == "hammerdb"
 
       when: not metadata_collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete")
 

--- a/roles/redis-collection/tasks/main.yml
+++ b/roles/redis-collection/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+
+- name: Get status code of the test
+  command: redis-cli hget uperf-test status
+  register: status_code
+
+- debug:
+    msg: "The status code for the test with uuid {{uuid}} and parameters as {{uperf.test_types}}-{{uperf.protos}}-{{uperf.sizes}}-{{uperf.nthrs}} is {{status_code.stdout}}"
+
+
+- block:
+
+  - block:
+    - name: Get Server Pods
+      k8s_facts:
+        kind: Pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - type = uperf-bench-server-{{ trunc_uuid }}
+      register: server_pods
+
+    - name: Pod names - to clean
+      set_fact:
+        clean_pods: |
+            [
+            {% for item in server_pods.resources %}
+              "{{ item['metadata']['name'] }}",
+            {% endfor %}
+            ]
+
+    - name: Cleanup run
+      k8s:
+        kind: pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        state: absent
+        name: "{{ item }}"
+      with_items: "{{ clean_pods }}"
+
+  - k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Failed
+        complete: true
+
+  - name: Delete benchmark
+    k8s:
+      kind: benchmark
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      namespace: '{{ operator_namespace }}'
+      state: absent
+      name: "uperf-benchmark"
+
+  - debug:
+      msg: "TEST FAILED: Deleting the benchmark..."
+
+  when: status_code.stdout == "1"
+
+

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -56,7 +56,6 @@ spec:
 {% if elasticsearch.server is defined %}
              export es={{elasticsearch.server}};
              export es_port={{elasticsearch.port}};
-             export uuid={{uuid}};
 {% endif %}
 {% endif %}
 {% if test_user is defined %}
@@ -69,9 +68,17 @@ spec:
              export client_node=UNSET;
              export server_node=UNSET;
 {% endif %}
+{% if redis_collection is defined %}
+             export redis_collection={{redis_collection}};
+{% else %}
+             export redis_collection=False;
+{% endif %}
              export clustername={{clustername}};
              export hostnet={{uperf.hostnetwork}};
              export ips=$(hostname -I);
+             export uuid={{uuid}};
+             export redis_port={{bo.resources[0].spec.containers[2].ports[0].containerPort}};
+             export bo_ip={{bo.resources[0].status.podIP}};
              while true; do
                if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true' ]]; then
 {% for test in uperf.test_types %}


### PR DESCRIPTION
@jtaleric @aakarshg @chaitanyaenr
Instead of adding the logic to the workload template (PR #282), a new role was added for redis_collection.
With redis_collection defined in the PR the test will abort if failed (delete benchmark), else it will continue (like we do now).

CR snip
```
apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
kind: Benchmark
metadata:
  name: uperf-benchmark
  namespace: my-ripsaw
spec:
  redis_collection: true
  clustername: myk8scluster
```
workflow
```
uperf-benchmark   uperf   Starting   not collected    a01e56c9-69d2-5ad9-90f7-8a0a7cd88999   45s
uperf-benchmark   uperf   Running   not collected    a01e56c9-69d2-5ad9-90f7-8a0a7cd88999   96s
uperf-benchmark   uperf   Failed   not collected    a01e56c9-69d2-5ad9-90f7-8a0a7cd88999   97s
No resources found in my-ripsaw namespace.
```
ansible logs
```
TASK [redis-collection : Get status code of the test] **************************
    "msg": "The status code for the test with uuid 8c472b1d-e237-5d49-9fe3-2623cfdd5c54 and parameters as [u'stream']-[u'tcp']-[16384]-[1, 8, 1, 8] is "
TASK [redis-collection : Get status code of the test] **************************
    "msg": "The status code for the test with uuid 8c472b1d-e237-5d49-9fe3-2623cfdd5c54 and parameters as [u'stream']-[u'tcp']-[16384]-[1, 8, 1, 8] is 2"
TASK [redis-collection : Get status code of the test] **************************
    "msg": "The status code for the test with uuid 8c472b1d-e237-5d49-9fe3-2623cfdd5c54 and parameters as [u'stream']-[u'tcp']-[16384]-[1, 8, 1, 8] is 1"
TASK [redis-collection : Get Server Pods] **************************************
TASK [redis-collection : Pod names - to clean] *********************************
TASK [redis-collection : Cleanup run] ******************************************
TASK [redis-collection : k8s_status] *******************************************
TASK [redis-collection : Delete benchmark] *************************************
TASK [redis-collection : debug] ************************************************
task path: /opt/ansible/roles/redis-collection/tasks/main.yml:58
ok: [localhost] => {
    "msg": "TEST FAILED: Deleting the benchmark..."
TASK [include_role : uperf-bench] **********************************************
TASK [uperf-bench : Get current state] *****************************************
TASK [uperf-bench : k8s_status] ************************************************
```

Scope for improvement in this PR
1. As you can see in the ansible logs, after `TASK: Delete benchmark` it still executes the playbook for the next role. It doesn't go much further as the benchmark is deleted but any suggestions on how to stop it all-together at  `TASK [redis-collection : debug]` will be appreciated
2. After a failed run the redis backend has the status of 1, so for the next run it catches that and aborts. This is easy to solve while running from plow where I can just delete the benchmark-operator pod and it'll be back up with a clean copy of it. But if there is an inherent solution from the role file it would be better. (I tried resetting it from the role but it failed in deleting the benchmark)

Scope for improvement in the future
1. with the now closed snafu PR (https://github.com/cloud-bulldozer/snafu/pull/136) we can send redis the exact test which failed and ripsaw can learn that and try to rerun that particular test