### PR TITLE
Configure uperf compute resources

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -17,6 +17,20 @@ spec:
   workload:
     name: uperf
     args:
+      client_resources:
+        requests:
+          cpu: 500m
+          memory: 500Mi
+        limits:
+          cpu: 500m
+          memory: 500Mi
+      server_resources:
+        requests:
+          cpu: 500m
+          memory: 500Mi
+        limits:
+          cpu: 500m
+          memory: 500Mi
       serviceip: false
       hostnetwork: false
       pin: false
@@ -37,6 +51,8 @@ spec:
         - 1
       runtime: 30
 ```
+
+`client_resources` and `server_resources` will create uperf client's and server's containers with the given k8s compute resources respectively [k8s resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -18,6 +18,9 @@ spec:
   containers:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/uperf:latest"
+{% if uperf.server_resources is defined %}
+    resources: {{ uperf.server_resources | to_json }}
+{% endif %}
     imagePullPolicy: Always
     wait: true
     command: ["/bin/sh","-c"]

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -38,6 +38,9 @@ spec:
       containers:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/uperf:latest"
+{% if uperf.client_resources is defined %}
+        resources: {{ uperf.client_resources | to_json }}
+{% endif %}
         imagePullPolicy: Always
         wait: true
         command: ["/bin/sh", "-c"]

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -1,0 +1,44 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  cleanup: false
+  workload:
+    name: uperf
+    args:
+      client_resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      server_resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      hostnetwork: false
+      serviceip: false
+      pin: false
+      pin_server: "node-0"
+      pin_client: "node-1"
+      multus:
+        enabled: false
+      samples: 2
+      pair: 1
+      test_types:
+        - stream
+        - rr
+      protos:
+        - tcp
+        - udp
+      sizes:
+        - 1024
+        - 512
+      nthrs:
+        - 1
+        - 2
+      runtime: 2


### PR DESCRIPTION
In order to use CPU manager capabilities at uperf containers we should be able to configure compute resources to get a guaranteed QoS on pods.