### PR TITLE
lengthen the fs-drift CI test to 15

### DIFF
--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -20,4 +20,4 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 5
+      duration: 15


### PR DESCRIPTION
original duration was 5 seconds, but
fs-drift default report interval[ changed from 1 to 5 sec](https://github.com/parallel-fs-utils/fs-drift/commit/86150806bc426d4675a43f55c9d42bcc011b1cfe),
so no records were getting generated for thread counters
causing CI test to fail when it looked for records in
corresponding index.