### PR TITLE
Add block to pre-fill cluster if fiod.prefill is true

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -29,6 +29,7 @@ spec:
   workload:
     name: "fio_distributed"
     args:
+      prefill: true
       samples: 3
       servers: 3
       pin_server: ''
@@ -168,7 +169,8 @@ The workload loops are nested as such from the CR options:
 - **rook_ceph_drop_caches**: (optional) If set to `True`, the Rook-Ceph OSD caches will be dropped prior to each sample
 - **rook_ceph_drop_cache_pod_ip**: (optional) The IP address of the pod hosting the Rook-Ceph cache drop URL -- See [cache drop pod instructions](#dropping-rook-ceph-osd-caches) below
 > Technical Note: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.
-
+- **prefill**: (Optional) boolean to enable/disable prefill SDS <br />
+--  prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
 #### EXPERT: spec.global_overrides
 The `key=value` combinations provided in the list here will be appended to the `[global]` section of the fio
 jobfile configmap. These options will therefore override the global values for all workloads in the loop.

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -38,6 +38,14 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - "cat /tmp/host/hosts;
+{% if fiod.prefill is defined and fiod.prefill is sameas true %}
+             echo ***************Prefill*****************;
+             cat /tmp/fio/fiojob-prefill;
+             mkdir -p /tmp/fiod-{{ uuid }}/fiojob-prefill;
+             fio --client=/tmp/host/hosts /tmp/fio/fiojob-prefill --output-format=json;
+             sleep 300;
+             echo ***********End of Prefill*************;
+{% endif %}
 {% for numjobs in fiod.numjobs %}
 {% for bs in fiod.bs %}
 {% for job in fiod.jobs %}

--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -5,6 +5,26 @@ metadata:
   name: fio-test-{{ trunc_uuid }}
   namespace: '{{ operator_namespace }}'
 data:
+{% if fiod.prefill is defined and fiod.prefill is sameas true %}
+  fiojob-prefill: |
+    [global]
+    directory={{fio_path}}
+    filename_format=f.\$jobnum.\$filenum
+    clocksource=clock_gettime
+    kb_base=1000
+    unit_base=8
+    ioengine=libaio
+    size={{fiod.filesize}}
+    bs=4096KiB
+    iodepth=1
+    direct=1
+    numjobs=1
+    
+    [write]
+    rw=write
+    create_on_open=1
+    fsync_on_close=1
+{% endif %}
 {% for numjobs in fiod.numjobs %}
 {% for bs in fiod.bs %}
 {% for job in fiod.jobs %}
@@ -20,7 +40,7 @@ data:
     log_hist_msec={{fiod.log_sample_rate}}
     clocksource=clock_gettime
     kb_base=1000
-    unit_base='8'
+    unit_base=8
     ioengine=libaio
     size={{fiod.filesize}}
     bs={{bs}}

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -12,6 +12,7 @@ spec:
   workload:
     name: "fio_distributed"
     args:
+      prefill: true
       samples: 2
       servers: 2
       jobs:
@@ -28,6 +29,7 @@ spec:
       read_ramp_time: 1
       filesize: 10MiB
       log_sample_rate: 1000
+      storagesize: 16Mi
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################


### PR DESCRIPTION
Added logic to fio-distributed to pre-fill the cluster before running the user provided test. 

This PR un-blocks the perf-sclae team with testing OCS.

@aakarshg @bengland2 @jtaleric @dry923 @dustinblack 