### PR TITLE
Fixing potential infinite loop when logging errors

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -225,12 +225,18 @@ function wait_for() {
 }
 
 function error {
+  if [[ $ERRORED == "true" ]]
+  then
+    exit
+  fi
+
+  ERRORED=true
+
   echo "Error caught. Dumping logs before exiting"
   echo "Benchmark operator Logs"
   kubectl -n my-ripsaw logs --tail=40 -l name=benchmark-operator -c benchmark-operator
   echo "Ansible sidecar Logs"
   kubectl -n my-ripsaw logs -l name=benchmark-operator -c ansible
-  ERRORED=true
 }
 
 function wait_for_backpack() {


### PR DESCRIPTION
There is a case where we may error out during one of the log messages below which will cause us to re-error. Moving the ERRORED state change above and adding an if statement should resolve this.