### PR TITLE
fix fiojob for fio-3.19

### DIFF
--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -20,7 +20,7 @@ data:
     log_hist_msec={{fiod.log_sample_rate}}
     clocksource=clock_gettime
     kb_base=1000
-    unit_base='8'
+    unit_base=8
     ioengine=libaio
     size={{fiod.filesize}}
     bs={{bs}}


### PR DESCRIPTION
for the latest version of fio (3.19), unit_base in job file doesnt
support string