### PR TITLE
Add pre-run initContainer to Fio workload

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -29,7 +29,6 @@ the workload template with an init container section that looks like:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/docs/prerun.md
+++ b/docs/prerun.md
@@ -1,0 +1,91 @@
+# Pre-run init containers
+
+Sometimes we need to prepare the environment before triggering a workload with some actions such as dropping caches, creating a directory structure or execute a script.
+
+Several Ripsaw's workloads have a customizable [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that will be launched before the actual workload.
+
+Ripsaw allows to customize the command and image launched by this initContainer through the variables `pre_run_cmd` and `pre_run_image`. Where `pre_run_cmd` configures the
+command to execute in the initContainer and `pre_run_image` overrides the initContainer container image, which by default corresponds with the workload image.
+
+## Init volumes and options
+
+The pre-run initContainer mounts the same data volumes as the parent workloads. So it will be able to access to the same data.
+Setting `privileged_pre_run` to true executes re-run initContainer as privileged, which may be useful to perform privileged actions such as configuring or drop caches or access hostPath volumes data.
+
+## Workloads using pre-run initContainers
+
+We can make use of pre-run initContainers in the following workloads:
+
+- Fio: pre-run is executed in each Fio server pod.
+
+## How it works
+
+The pre-run initContainer executes from a shell the command given by the variable `pre_run_cmd`, it defaults to a simple `exit 0` if this variable is not configured.
+The command is executed from a container image given by the variable `pre_run_image` which defaults to the workload image, in the example below `quay.io/cloud-bulldozer/fio:latest`.
+
+The following code snippet has been extracted from the Fio server job template:
+
+```yaml
+      initContainers:
+      - name: pre-run
+        image: {{ pre_run_image|default("quay.io/cloud-bulldozer/fio:latest", true) }}
+        command: ["/bin/sh"]
+        args: ["-c", "{{ pre_run_cmd|default("exit 0", true) }}"]
+{% if fiod.storageclass is defined or hostpath is defined %}
+        volumeMounts:
+        - name: data-volume
+          mountPath: "{{ fio_path }}"
+{% endif %}
+        securityContext:
+          privileged: {{ privileged_pre_run|default(false, true) }}
+```
+
+The following example triggers an initContainer to drop caches before running the actual Fio workload. Note the value of the `privileged_pre_run` flag.
+
+
+```yaml
+piVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: fio-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "marquez.perf.lab.eng.rdu2.redhat.com"
+    port: 9200
+  metadata_collection: true
+  privileged_pre_run: true
+  pre_run_cmd: "echo 3 > /proc/sys/vm/drop_caches"
+  workload:
+    name: "fio_distributed"
+    args:
+      samples: 1
+      servers: 2
+      jobs:
+        - write
+        - read
+      bs:
+        - 4KiB
+      numjobs:
+        - 1
+      iodepth: 2
+      read_runtime: 3
+      read_ramp_time: 1
+      filesize: 10MiB
+      log_sample_rate: 1000
+    - jobname_match: w
+      params:
+        - fsync_on_close=1
+```
+
+It's also possible to introduce more than one command in the pre-run initContainer, there must be a semicolon at the end of each command as shown below.
+
+```yaml
+  pre_run_cmd: |
+    mkdir -p /my/directory/struct;
+    for f in my list of files; do
+      cat /dev/zero | dd iflag=fullblock of=/my/directory/struct/${f} bs=1024K count=10;
+    done;
+    sync
+```
+

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -26,7 +26,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name; sleep infinity"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         readinessProbe:

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -17,7 +17,6 @@ spec:
         args: ["{{ byowl.commands }}"]
         image: "{{ byowl.image }}"
         imagePullPolicy: Always
-        wait: true
       restartPolicy: OnFailure
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
@@ -26,7 +25,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -15,7 +15,6 @@ spec:
       - name: fio-client
         image: "quay.io/cloud-bulldozer/fio:latest"
         imagePullPolicy: Always
-        wait: true
         env:
           - name: uuid
             value: "{{ uuid }}"
@@ -68,7 +67,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -33,7 +33,6 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 8765
-        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "cd /tmp; fio --server"
@@ -60,14 +59,24 @@ spec:
           path: {{ hostpath }}
           type: DirectoryOrCreate
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
+      - name: pre-run
+        image: {{ pre_run_image|default("quay.io/cloud-bulldozer/fio:latest", true) }}
+        command: ["/bin/sh"]
+        args: ["-c", "{{ pre_run_cmd|default("exit 0", true) }}"]
+{% if fiod.storageclass is defined or hostpath is defined %}
+        volumeMounts:
+        - name: data-volume
+          mountPath: "{{ fio_path }}"
+{% endif %}
+        securityContext:
+          privileged: {{ privileged_pre_run|default(false, true) }}
+{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -37,7 +37,6 @@ spec:
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
-          wait: true
           env:
           - name: uuid
             value: "{{ uuid }}"
@@ -101,7 +100,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -35,7 +35,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/hammerdb/templates/db_workload.yml.j2
+++ b/roles/hammerdb/templates/db_workload.yml.j2
@@ -15,7 +15,6 @@ spec:
       - name: hammerdb
         image: "quay.io/cloud-bulldozer/hammerdb:master"
         imagePullPolicy: Always
-        wait: true
         command: ["/bin/sh", "-c"]
         args: 
           - "/usr/local/bin/uid_entrypoint; 
@@ -58,7 +57,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -22,7 +22,6 @@ spec:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
         imagePullPolicy: Always
-        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "iperf3 -c {{ item.status.podIP }} -p {{ iperf3.port }} --{{ iperf3.transmit_type }} {{ iperf3.transmit_value }} -l {{ iperf3.length_buffer }} -P {{ iperf3.streams }} -w {{ iperf3.window_size }} -M {{ iperf3.mss }} -S {{ iperf3.ip_tos }} -O {{ iperf3.omit_start }} {{ iperf3.extra_options_client }}"
@@ -38,7 +37,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/iperf3-bench/templates/client_store.yml.j2
+++ b/roles/iperf3-bench/templates/client_store.yml.j2
@@ -22,7 +22,6 @@ spec:
       - name: benchmark
         image: "quay.io/cloud-bulldozer/iperf3:latest"
         imagePullPolicy: Always
-        wait: true
         command: ["/bin/sh", "-c"]
         args:
           - "mkdir -p {{results.path}}/iperf3-{{ uuid }};

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -16,7 +16,6 @@ spec:
   - name: benchmark
     image: "quay.io/cloud-bulldozer/iperf3:latest"
     imagePullPolicy: Always
-    wait: true
     command: ["/bin/sh", "-c"]
     args:
       - "iperf3 -s -p {{ iperf3.port }} {{ iperf3.extra_options_server }}"
@@ -32,7 +31,6 @@ spec:
     command: ["/bin/sh", "-c"]
     args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
     imagePullPolicy: Always
-    wait: true
     securityContext:
       privileged: {{ metadata_privileged | default(false) | bool }}
     env:

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -15,7 +15,6 @@ spec:
       - name: benchmark
         image: "{{ pgb_base_image }}:{{ pgb_version }}"
         imagePullPolicy: Always
-        wait: true
         env:
           - name: PGPASSWORD
             value: '{{ item.1.password }}'
@@ -80,7 +79,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -37,7 +37,6 @@ spec:
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
-          wait: true
           env:
           - name: uuid
             value: "{{ uuid }}"
@@ -106,7 +105,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -18,7 +18,6 @@ spec:
         args: ["/tmp/sysbenchScript"]
         image: "quay.io/cloud-bulldozer/sysbench:latest"
         imagePullPolicy: Always
-        wait: true
         volumeMounts:
         - name: sysbench-volume
           mountPath: "/tmp/"
@@ -35,7 +34,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -22,7 +22,6 @@ spec:
     resources: {{ uperf.server_resources | to_json }}
 {% endif %}
     imagePullPolicy: Always
-    wait: true
     command: ["/bin/sh","-c"]
     args: ["uperf -s -v -P 20000"]
   restartPolicy: OnFailure
@@ -43,7 +42,6 @@ spec:
     command: ["/bin/sh", "-c"]
     args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
     imagePullPolicy: Always
-    wait: true
     securityContext:
       privileged: {{ metadata_privileged | default(false) | bool }}
     env:

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -42,7 +42,6 @@ spec:
         resources: {{ uperf.client_resources | to_json }}
 {% endif %}
         imagePullPolicy: Always
-        wait: true
         command: ["/bin/sh", "-c"]
         args:
 {% if uperf.serviceip is sameas true %}
@@ -114,7 +113,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always
-        wait: true
         securityContext:
           privileged: {{ metadata_privileged | default(false) | bool }}
         env:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -9,6 +9,7 @@ spec:
     port: 9200
   metadata_collection: true
   cleanup: false
+  pre_run_cmd: "touch {{ fio_path }}/prerun"
   workload:
     name: "fio_distributed"
     args:

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -9,6 +9,8 @@ spec:
     port: 9200
   metadata_collection: true
   cleanup: false
+  privileged_pre_run: true
+  pre_run_cmd: "touch {{ fio_path }}/prerun"
   hostpath: /mnt/vda1/fiod/
   workload:
     name: "fio_distributed"

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -29,7 +29,7 @@ function functional_test_fio {
   wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=500s" "500s" $fio_pod
   wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs -n my-ripsaw --timeout=500s" "500s" $fio_pod
   # ensuring the run has actually happened
-  kubectl logs "$fio_pod" -n my-ripsaw
+  kubectl logs "$fio_pod" -n my-ripsaw --all-containers
   kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
   echo "${test_name} test: Success"
 }


### PR DESCRIPTION
Sometimes we need to prepare the environment before triggering a workload with some actions such as dropping caches, creating a directory structure or execute a script.

With this PR, Fio ripsaw's workload triggers a customizable [initContainer](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that will be launched before the actual workload.

This PR also cleans up the deprecated `wait` flag from some of the workloads.
