### PR TITLE
Upstream UPerf

### DIFF
--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -24,7 +24,7 @@ spec:
     imagePullPolicy: Always
     wait: true
     command: ["/bin/sh","-c"]
-    args: ["uperf -s -v -P 20000"]
+    args: ["uperf -s -v"]
   restartPolicy: OnFailure
 {% if uperf.pin is sameas true %}
   nodeSelector:

--- a/roles/uperf-bench/templates/server_vm.yml.j2
+++ b/roles/uperf-bench/templates/server_vm.yml.j2
@@ -62,6 +62,6 @@ spec:
           - yum copr enable ndokos/pbench -y
           - yum install -y pbench-uperf redis git
           - redis-cli -h {{ bo.resources[0].status.podIP }} set {{ trunc_uuid }} true
-          - uperf -s -v -P 20000
+          - uperf -s -v
     name: cloudinitdisk
 status: {}


### PR DESCRIPTION
Moving to the upstream UPerf. Which defaults to port 20000 and removes
the `-P` option.