### PR TITLE
Adding logic to backpack to only run on a node once for a given uuid

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,6 +10,15 @@
       namespace: '{{ operator_namespace }}'
     register: cr_state
 
+  - name: Capture operator information
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: "{{ operator_namespace }}"
+      label_selectors:
+        - name = benchmark-operator
+    register: bo
+
   - debug:
       msg: "{{ cr_state }}"
 
@@ -43,7 +52,7 @@
       
       - include_role:
           name: backpack
-        when: not metadata_targeted | default('true') | bool
+        when: metadata is defined and not metadata.targeted | default('true') | bool
 
       - k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
@@ -52,9 +61,9 @@
           namespace: "{{ operator_namespace }}"
           status:
             metadata: "Collecting"
-        when: metadata_targeted | default('true') | bool and not cr_state.resources[0].status.state is defined
+        when: metadata is defined and metadata.targeted | default('true') | bool and not cr_state.resources[0].status.state is defined
     
-      when: metadata_collection is defined and metadata_collection | default('false') | bool and (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata != "Complete")
+      when: metadata is defined and metadata.collection | default('false') | bool and (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata != "Complete")
 
     - block:
 
@@ -125,6 +134,6 @@
           hammerdb: "{{ workload.args }}"
         when: workload.name == "hammerdb" 
 
-      when: not metadata_collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete") or metadata_targeted | default('true') | bool
+      when: metadata is not defined or not metadata.collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete") or metadata.targeted | default('true') | bool
     
     when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -37,12 +37,9 @@ spec:
                 type: array
                 items:
                   type: object
-              metadata_collection:
-                type: boolean
-              metadata_privledged:
-                type: boolean
-              metadata_targeted:
-                type: boolean
+              metadata:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
               cleanup:
                 type: boolean
               test_user: 

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -24,11 +24,17 @@ spec:
       - name: backpack
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name; sleep infinity"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force; sleep infinity"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379; sleep infinity"]
+{% endif %}
         imagePullPolicy: Always
         wait: true
-        securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+{% if metadata is defined and metadata.privileged is defined %}
+       securityContext:
+          privileged: {{ metadata.privileged | default(false) | bool }}
+{% endif %}
         readinessProbe:
           exec:
             command:
@@ -46,5 +52,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+{% if metadata is defined and metadata.serviceaccount is defined %}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
+{% endif %}
       terminationGracePeriodSeconds: 30

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -19,16 +19,20 @@ spec:
         imagePullPolicy: Always
         wait: true
       restartPolicy: OnFailure
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -38,5 +42,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -69,16 +69,20 @@ spec:
           name: "fio-hosts-{{ trunc_uuid }}"
           defaultMode: 0777
       restartPolicy: Never
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -88,5 +92,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -60,16 +60,20 @@ spec:
           path: {{ hostpath }}
           type: DirectoryOrCreate
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -79,5 +83,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('benchmark-operator') }}
 {% endif %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -94,16 +94,20 @@ spec:
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -113,5 +117,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('benchmark-operator') }}
 {% endif %}

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -28,16 +28,20 @@ spec:
           name: "{{ meta.name }}-creator-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -47,5 +51,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/hammerdb/templates/db_workload.yml.j2
+++ b/roles/hammerdb/templates/db_workload.yml.j2
@@ -51,16 +51,20 @@ spec:
           name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -70,5 +74,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -31,16 +31,20 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ iperf3.pin_client }}'
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -50,5 +54,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -25,16 +25,20 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: '{{ iperf3.pin_server }}'
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
   initContainers:
   - name: backpack-{{ trunc_uuid }}
     image: quay.io/cloud-bulldozer/backpack:latest
     command: ["/bin/sh", "-c"]
-    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}    
     imagePullPolicy: Always
     wait: true
     securityContext:
-      privileged: {{ metadata_privileged | default(false) | bool }}
+      privileged: {{ metadata.privileged | default(false) | bool }}
     env:
       - name: my_node_name
         valueFrom:
@@ -44,5 +48,5 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-  serviceAccountName: {{ metadata_sa | default('default') }}
+  serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -73,16 +73,20 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: '{{ item.1.pin_node }}'
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -92,5 +96,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -99,16 +99,20 @@ spec:
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -118,5 +122,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('benchmark-operator') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('benchmark-operator') }}
 {% endif %}

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -28,16 +28,20 @@ spec:
           name: "sysbench-config-{{ trunc_uuid }}"
           defaultMode: 0777
       restartPolicy: OnFailure
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}        
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -47,5 +51,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -36,16 +36,20 @@ spec:
     - name: net.ipv4.ip_local_port_range
       value: 20000 20011
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
   initContainers:
   - name: backpack-{{ trunc_uuid }}
     image: quay.io/cloud-bulldozer/backpack:latest
     command: ["/bin/sh", "-c"]
-    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+    args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
     imagePullPolicy: Always
     wait: true
     securityContext:
-      privileged: {{ metadata_privileged | default(false) | bool }}
+      privileged: {{ metadata.privileged | default(false) | bool }}
     env:
       - name: my_node_name
         valueFrom:
@@ -55,5 +59,5 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-  serviceAccountName: {{ metadata_sa | default('default') }}
+  serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -109,16 +109,20 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ uperf.pin_client }}'
 {% endif %}
-{% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: quay.io/cloud-bulldozer/backpack:latest
         command: ["/bin/sh", "-c"]
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
         imagePullPolicy: Always
         wait: true
         securityContext:
-          privileged: {{ metadata_privileged | default(false) | bool }}
+          privileged: {{ metadata.privileged | default(false) | bool }}
         env:
           - name: my_node_name
             valueFrom:
@@ -128,5 +132,5 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-      serviceAccountName: {{ metadata_sa | default('default') }}
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
 {% endif %}

--- a/tests/test_crs/valid_backpack.yaml
+++ b/tests/test_crs/valid_backpack.yaml
@@ -7,8 +7,9 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
-  metadata_targeted: false
+  metadata:
+    collection: true
+    targeted: false
   workload:
     name: byowl
     args:

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: byowl
     args:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   cleanup: false
   workload:
     name: "fio_distributed"

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   cleanup: false
   hostpath: /mnt/vda1/fiod/
   workload:

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -12,7 +12,8 @@ spec:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
   es_index: ripsaw-fs-drift
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: fs-drift
     args:

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -12,7 +12,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   hostpath: /mnt/vda1/fs_drift
   workload:
     name: fs-drift

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: "hammerdb"
     args:

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: iperf3
     args:

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: "pgbench"
     args:

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -12,7 +12,8 @@ spec:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
   es_index: ripsaw-smallfile
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: smallfile
     args:

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -13,7 +13,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   hostpath: /mnt/vda1/smallfile
   workload:
     name: smallfile

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   workload:
     name: sysbench
     args:

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   cleanup: false
   workload:
     name: uperf

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   cleanup: false
   workload:
     name: uperf

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -7,7 +7,8 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
+  metadata:
+    collection: true
   cleanup: false
   workload:
     name: uperf

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -7,8 +7,9 @@ spec:
   elasticsearch:
     server: "marquez.perf.lab.eng.rdu2.redhat.com"
     port: 9200
-  metadata_collection: true
-  metadata_targeted: false
+  metadata:
+    collection: true
+    targeted: false
   workload:
     name: ycsb
     args:


### PR DESCRIPTION
Note: This needs to be merged after https://github.com/cloud-bulldozer/bohica/pull/10 and https://github.com/cloud-bulldozer/backpack/pull/3

This will add the ability for backpack to only run on a node once per each uuid. So if 3 pods land on the same node for the same workload it will only collect the data once. The init container will still run and then complete with a message saying that the data was already collected.