### PR TITLE
Adding logic to CI testing to check ES for workload results

### DIFF
--- a/resources/backpack_role.yaml
+++ b/resources/backpack_role.yaml
@@ -107,6 +107,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/check_es.py
+++ b/tests/check_es.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import argparse
+import elasticsearch
+import sys
+
+def _check_index(server,port,uuid,index,es_ssl):
+    _es_connection_string = str(server) + ':' + str(port)
+
+    if es_ssl == "true":
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+        es = elasticsearch.Elasticsearch([_es_connection_string], send_get_body_as='POST',
+                                                 ssl_context=ssl_ctx, use_ssl=True)
+    else:
+        es = elasticsearch.Elasticsearch([_es_connection_string], send_get_body_as='POST')
+    results = es.search(index=index, body={'query': {'term': {'uuid.keyword': uuid}}}, size=1)
+    if results['hits']['total']['value'] > 0:
+        return 0
+    else:
+        print("No result found in ES")
+        return 1
+
+def main():
+    parser = argparse.ArgumentParser(description="Script to verify uploads to ES")
+    parser.add_argument(
+        '-s', '--server',
+        help='Provide elastic server information')
+    parser.add_argument(
+        '-p', '--port',
+        help='Provide elastic port information')
+    parser.add_argument(
+        '-u', '--uuid',
+        help='UUID to provide to search')
+    parser.add_argument(
+        '-i', '--index',
+        help='Index to provide to search')
+    parser.add_argument(
+        '--sslskipverify',
+        help='if es is setup with ssl, but can disable tls cert verification',
+        default=False)
+    args = parser.parse_args()
+
+    sys.exit(_check_index(args.server,args.port,args.uuid,args.index,args.sslskipverify))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -21,7 +21,8 @@ function functional_test_byowl {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
   
   byowl_pod=$(get_pod "app=byowl-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=500s" "500s" $byowl_pod

--- a/tests/test_crs/valid_backpack.yaml
+++ b/tests/test_crs/valid_backpack.yaml
@@ -10,6 +10,8 @@ spec:
   metadata:
     collection: true
     targeted: false
+    privileged: true
+    serviceaccount: backpack-view
   workload:
     name: byowl
     args:

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -22,7 +22,9 @@ function functional_test_fio {
   cr=$2
   echo "Performing: ${test_name}"
   kubectl apply -f ${cr}
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
   pod_count "app=fio-benchmark-$uuid" 2 300  
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=fio-benchmark-$uuid pods --timeout=300s" "300s"
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
@@ -31,7 +33,15 @@ function functional_test_fio {
   # ensuring the run has actually happened
   kubectl logs "$fio_pod" -n my-ripsaw
   kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
-  echo "${test_name} test: Success"
+
+  index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    exit 1
+  fi
 }
 
 figlet $(basename $0)

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -4,38 +4,42 @@ set -xeo pipefail
 source tests/common.sh
 
 function initdb_pod {
-	echo "Setting up a MS-SQL DB Pod"
-	kubectl apply -f tests/mssql.yaml
-        mssql_pod=$(get_pod "app=mssql" 300 "sql-server")
-	kubectl wait --for=condition=Ready "pods/$mssql_pod" --namespace sql-server --timeout=300s
+  echo "Setting up a MS-SQL DB Pod"
+  kubectl apply -f tests/mssql.yaml
+  mssql_pod=$(get_pod "app=mssql" 300 "sql-server")
+  kubectl wait --for=condition=Ready "pods/$mssql_pod" --namespace sql-server --timeout=300s
 }
 
 function finish {
-	echo "Cleaning up hammerdb"
-	kubectl delete -f tests/mssql.yaml 
-	kubectl delete -f tests/test_crs/valid_hammerdb.yaml
-	delete_operator
+  echo "Cleaning up hammerdb"
+  kubectl delete -f tests/mssql.yaml 
+  kubectl delete -f tests/test_crs/valid_hammerdb.yaml
+  delete_operator
 }
 
 trap finish EXIT
 
 function functional_test_hammerdb {
-	initdb_pod
-	apply_operator
-	kubectl apply -f tests/test_crs/valid_hammerdb.yaml
-	uuid=$(get_uuid 20)
+  initdb_pod
+  apply_operator
+  kubectl apply -f tests/test_crs/valid_hammerdb.yaml
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
 
-	# Wait for the creator pod to initialize the DB
-        #DISABLED
-	#hammerdb_creator_pod=$(get_pod "app=hammerdb_creator-$uuid" 300)
-	#kubectl wait --for=condition=Initialized "pods/$hammerdb_creator_pod" --namespace my-ripsaw --timeout=100s
-	#kubectl wait --for=condition=complete -l app=hammerdb_creator-$uuid --namespace my-ripsaw jobs --timeout=600s
-	# Wait for the workload pod to run the actual workload
-	hammerdb_workload_pod=$(get_pod "app=hammerdb_workload-$uuid" 300)
-	kubectl wait --for=condition=Initialized "pods/$hammerdb_workload_pod" --namespace my-ripsaw --timeout=400s
-	kubectl wait --for=condition=complete -l app=hammerdb_workload-$uuid --namespace my-ripsaw jobs --timeout=500s
-	kubectl logs "$hammerdb_workload_pod" --namespace my-ripsaw | grep "Timestamp"
-	echo "Hammerdb test: Success"
+  # Wait for the workload pod to run the actual workload
+  hammerdb_workload_pod=$(get_pod "app=hammerdb_workload-$uuid" 300)
+  kubectl wait --for=condition=Initialized "pods/$hammerdb_workload_pod" --namespace my-ripsaw --timeout=400s
+  kubectl wait --for=condition=complete -l app=hammerdb_workload-$uuid --namespace my-ripsaw jobs --timeout=500s
+  kubectl logs "$hammerdb_workload_pod" --namespace my-ripsaw | grep "Timestamp"
+
+  index="ripsaw-hammerdb-results"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "Hammerdb test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    exit 1
+  fi
 }
 
 functional_test_hammerdb

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -21,7 +21,8 @@ function functional_test_iperf {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
 
   iperf_server_pod=$(get_pod "app=iperf3-bench-server-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=iperf3-bench-server-$uuid pods --timeout=300s" "300s" $iperf_server_pod

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -78,14 +78,23 @@ EOF
   done
   # deploy the test CR with the postgres pod IP
   sed s/host:/host:\ ${postgres_ip}/ tests/test_crs/valid_pgbench.yaml | kubectl apply -f -
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
 
   pgbench_pod=$(get_pod "app=pgbench-client-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=360s" "360s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client-$uuid -n my-ripsaw --timeout=300s" "300s" $pgbench_pod
   kubectl logs -n my-ripsaw $pgbench_pod | grep 'tps ='
-  echo "pgbench test: Success"
+
+  index="ripsaw-pgbench-summary ripsaw-pgbench-raw"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "pgbench test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    exit 1
+  fi
 }
 
 functional_test_pgbench

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -21,7 +21,8 @@ function functional_test_sysbench {
   figlet $(basename $0)
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
 
   sysbench_pod=$(get_pod "app=sysbench-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$sysbench_pod --namespace my-ripsaw --timeout=500s" "500s" $sysbench_pod

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -22,7 +22,9 @@ function functional_test_uperf {
   cr=$2
   echo "Performing: ${test_name}"
   kubectl apply -f ${cr}
-  uuid=$(get_uuid 20)
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
   pod_count "type=uperf-bench-server-$uuid" 1 900
   uperf_server_pod=$(get_pod "app=uperf-bench-server-0-$uuid" 300)
   wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=uperf-bench-server-0-$uuid pods --timeout=300s" "300s" $uperf_server_pod
@@ -32,7 +34,15 @@ function functional_test_uperf {
   # ensuring that uperf actually ran and we can access metrics
   kubectl logs "$uperf_client_pod" -n my-ripsaw
   kubectl logs "$uperf_client_pod" -n my-ripsaw | grep Success
-  echo "${test_name} test: Success"
+
+  index="ripsaw-uperf-results"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    exit 1
+  fi
 }
 
 figlet $(basename $0)


### PR DESCRIPTION
Added check_es python script that will check an ES instance for a given uuid and index. This is used to help validate that the tests ran and indexed properly. This was only added to workloads that utilize snafu.
Additionally, updated the backpack CI test to run as a privileged container with a service account. This way we can ensure we check as many of the functions of the pod as possible. However, I did have to add in a sleep after the workload was complete as ES seemed to take some time to process the data and make it available to check via the check_es script.