### PR TITLE
Adding a short sleep to each CI test run to avoid command collision

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -7,6 +7,9 @@ retries=3
 
 figlet $ci_test
 
+# Random short sleep to avoid command collision
+sleep $[ ( $RANDOM % 10 )]s
+
 cd $ci_dir
 source tests/common.sh
 


### PR DESCRIPTION
Adding a small (<10 second) random sleep to the start of each workload CI test. This is to help avoid potential command collision. 

This also may resolve https://github.com/cloud-bulldozer/ripsaw/issues/319