### PR TITLE
Fio yaml enhancements

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -12,23 +12,41 @@ spec:
   workload:
     name: "fio_distributed"
     args:
+      # if true, do large sequential write to preallocate volume before using
+      prefill: true
+      # number of times each test
       samples: 3
+      # number of fio pods generating workload
       servers: 3
+      # put all fio pods on this server
       pin_server: ''
+      # test types, see fio documentation
       jobs:
         - write
         - read
+        - randwrite
+        - randread
+      # I/O request sizes (also called block size)
       bs:
-        - 4KiB
-        - 64KiB
+        - 4k
+        - 64k
+      # how many fio processes per pod
       numjobs:
         - 1
-        - 8
+      # with libaio ioengine, number of in-flight requests per process
       iodepth: 4
-      read_runtime: 60
+      # how long to run write tests, this is TOO SHORT DURATION
+      read_runtime: 15
+      # how long to run read tests, this is TOO SHORT DURATION
+      write_runtime: 15
+      # don't start measuring until this many seconds pass, for reads
       read_ramp_time: 5
+      # don't start measuring until this many seconds pass, for writes
+      write_ramp_time: 5
+      # size of file to access 
       filesize: 2GiB
-      log_sample_rate: 1000
+      # interval between i/o stat samples in milliseconds
+      log_sample_rate: 3000
       #storageclass: rook-ceph-block
       #storagesize: 5Gi
       #rook_ceph_drop_caches: True
@@ -41,10 +59,12 @@ spec:
 #        fio server is running in a privileged pod
 #    - exec_prerun=bash -c 'sync && echo 3 > /proc/sys/vm/drop_caches'
   job_params:
-    - jobname_match: w
+    - jobname_match: write
       params:
         - fsync_on_close=1
         - create_on_open=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
     - jobname_match: read
       params:
         - time_based=1
@@ -62,6 +82,21 @@ spec:
         - time_based=1
         - runtime={{ fiod.read_runtime }}
         - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randread
+      params:
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randwrite
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
+    - jobname_match: randrw
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
 #    - jobname_match: <search_string>
 #      params:
 #        - key=value

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -43,7 +43,9 @@ spec:
              cat /tmp/fio/fiojob-prefill;
              mkdir -p /tmp/fiod-{{ uuid }}/fiojob-prefill;
              fio --client=/tmp/host/hosts /tmp/fio/fiojob-prefill --output-format=json;
-             sleep 300;
+{% if fiod.post_prefill_sleep is defined %}
+             sleep {{ fiod.post_prefill_sleep }};
+{% endif %}
              echo ***********End of Prefill*************;
 {% endif %}
 {% for numjobs in fiod.numjobs %}

--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -57,7 +57,7 @@ data:
 {% endif %}
 {% if job_params|default([])|length %}
 {% for match in job_params %}
-{% if match.jobname_match in job %}
+{% if match.jobname_match == job %}
 {% for param in match.params %}
     {{ param }}
 {% endfor %}

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -12,12 +12,14 @@ spec:
   workload:
     name: "fio_distributed"
     args:
-      prefill: true
       samples: 2
       servers: 2
       jobs:
         - write
         - read
+        - randwrite
+        - randread
+        - randrw
       bs:
         - 4KiB
         - 64KiB
@@ -25,19 +27,24 @@ spec:
         - 1
         - 2
       iodepth: 1
-      read_runtime: 3
+      read_runtime: 10
+      write_runtime: 10
       read_ramp_time: 1
+      write_ramp_time: 1
       filesize: 10MiB
-      log_sample_rate: 1000
+      log_sample_rate: 2000
       storagesize: 16Mi
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################
   job_params:
-    - jobname_match: w
+    - jobname_match: write
       params:
+        - time_based=1
         - fsync_on_close=1
         - create_on_open=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
     - jobname_match: read
       params:
         - time_based=1
@@ -55,3 +62,18 @@ spec:
         - time_based=1
         - runtime={{ fiod.read_runtime }}
         - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randread
+      params:
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randwrite
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
+    - jobname_match: randrw
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -15,9 +15,13 @@ spec:
     args:
       samples: 2
       servers: 2
+      prefill: true
       jobs:
         - write
         - read
+        - randwrite
+        - randread
+        - randrw
       bs:
         - 4KiB
         - 64KiB
@@ -25,18 +29,23 @@ spec:
         - 1
         - 2
       iodepth: 2
-      read_runtime: 3
+      read_runtime: 6
+      write_runtime: 6
       read_ramp_time: 1
+      write_ramp_time: 1
       filesize: 10MiB
-      log_sample_rate: 1000
+      log_sample_rate: 2000
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################
   job_params:
-    - jobname_match: w
+    - jobname_match: write
       params:
+        - time_based=1
         - fsync_on_close=1
         - create_on_open=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
     - jobname_match: read
       params:
         - time_based=1
@@ -54,4 +63,19 @@ spec:
         - time_based=1
         - runtime={{ fiod.read_runtime }}
         - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randread
+      params:
+        - time_based=1
+        - runtime={{ fiod.read_runtime }}
+        - ramp_time={{ fiod.read_ramp_time }}
+    - jobname_match: randwrite
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
+    - jobname_match: randrw
+      params:
+        - time_based=1
+        - runtime={{ fiod.write_runtime }}
+        - ramp_time={{ fiod.write_ramp_time }}
 


### PR DESCRIPTION
This has been tested with a 112-OSD Ceph cluster.   It allows for really quick tests to debug workload parameters, etc.  by making  the 300-second prefill sleep configurable (default 0).   But it can handle really long tests efficiently by leveraging Alex's prefill functionality to do the full file write only once with maximum I/O size, and then the actual write test is done on a time-limited basis.   Some fixes were needed to support each test type independently.   We need this for OCS QE.