### PR TITLE
Adding optional image location for workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 # Ignore
+*.swp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ un-block it. The benchmarks mentioned above that state `Used` for Reconciliation
 These two bencharmks are written in a way that doesn't allow for reconciliation to be implemented. To take
 advantage of the reconciliation loop, these two benchmarks need to be rewritten.
 
+## Optional workload images
+Optional locations for workload images can now be added easily without the need to rebuild the operator.
+To do so in the workload args section of the CR add image: [location]
+
+NOTE: This is not a required arguement. If omitted it will default to the currently verified workload image.
+Additionally, this is not enabled for YCSB
+
+For Example:
+
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "my-es.foo.bar"
+    port: 9200
+  metadata_collection: true
+  cleanup: false
+  workload:
+    name: "foo"
+    args:
+      image: my.location/foo:latest
+```
+
 ## Installation
 [Installation](docs/installation.md)
 

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -22,7 +22,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: backpack
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name; sleep infinity"]
         imagePullPolicy: Always

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -22,7 +22,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/fio-distributed/templates/client.yaml
+++ b/roles/fio-distributed/templates/client.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: fio-client
-        image: "quay.io/cloud-bulldozer/fio:latest"
+        image: {{ fiod.image | default('quay.io/cloud-bulldozer/fio:latest') }}
         imagePullPolicy: Always
         wait: true
         env:
@@ -72,7 +72,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -29,7 +29,7 @@ spec:
         securityContext:
           privileged: true
 {% endif %}
-        image: "quay.io/cloud-bulldozer/fio:latest"
+        image: {{ fiod.image | default('quay.io/cloud-bulldozer/fio:latest') }}
         imagePullPolicy: Always
         ports:
           - containerPort: 8765
@@ -63,7 +63,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -31,7 +31,7 @@ spec:
           securityContext:
             privileged: true
 {% endif %}
-          image: quay.io/cloud-bulldozer/fs-drift:master
+          image: {{ fs_drift.image | default('quay.io/cloud-bulldozer/fs-drift:master') }}
           # example of what to do when debugging image
           # image: quay.io/bengland2/fs-drift:latest
           imagePullPolicy: Always
@@ -97,7 +97,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -16,7 +16,7 @@ spec:
       - name: hammerdb
         command: ["/bin/sh", "-c"]
         args: ["/usr/local/bin/uid_entrypoint; cd /hammer; ./hammerdbcli auto /creator/createdb.tcl"]
-        image: "quay.io/cloud-bulldozer/hammerdb:latest"
+        image: {{ hammerdb.image | default('quay.io/cloud-bulldozer/hammerdb:latest') }}
         imagePullPolicy: Always
         volumeMounts:
         - name: hammerdb-creator-volume
@@ -31,7 +31,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/hammerdb/templates/db_workload.yml.j2
+++ b/roles/hammerdb/templates/db_workload.yml.j2
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: hammerdb
-        image: "quay.io/cloud-bulldozer/hammerdb:master"
+        image: {{ hammerdb.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}
         imagePullPolicy: Always
         wait: true
         command: ["/bin/sh", "-c"]
@@ -54,7 +54,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/iperf3-bench/templates/client.yml.j2
+++ b/roles/iperf3-bench/templates/client.yml.j2
@@ -20,7 +20,7 @@ spec:
 {% endif %}
       containers:
       - name: benchmark
-        image: "quay.io/cloud-bulldozer/iperf3:latest"
+        image: {{ iperf3.image | default('quay.io/cloud-bulldozer/iperf3:latest') }}
         imagePullPolicy: Always
         wait: true
         command: ["/bin/sh", "-c"]
@@ -34,7 +34,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/iperf3-bench/templates/server.yml.j2
+++ b/roles/iperf3-bench/templates/server.yml.j2
@@ -14,7 +14,7 @@ spec:
 {% endif %}
   containers:
   - name: benchmark
-    image: "quay.io/cloud-bulldozer/iperf3:latest"
+    image: {{ iperf3.image | default('quay.io/cloud-bulldozer/iperf3:latest') }}
     imagePullPolicy: Always
     wait: true
     command: ["/bin/sh", "-c"]
@@ -28,7 +28,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
   initContainers:
   - name: backpack-{{ trunc_uuid }}
-    image: quay.io/cloud-bulldozer/backpack:latest
+    image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
     command: ["/bin/sh", "-c"]
     args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
     imagePullPolicy: Always

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -76,7 +76,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/smallfile-bench/templates/workload_job.yml.j2
+++ b/roles/smallfile-bench/templates/workload_job.yml.j2
@@ -31,9 +31,7 @@ spec:
           securityContext:
             privileged: true
 {% endif %}
-          image: "quay.io/cloud-bulldozer/smallfile:master"
-          # example of how to debug using your own workload image
-          #image: "quay.io/bengland2/smallfile:master"
+          image: {{ smallfile.image | default('quay.io/cloud-bulldozer/smallfile:master') }}
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
@@ -102,7 +100,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -16,7 +16,7 @@ spec:
       - name: sysbench
         command: ["/bin/sh", "-c"]
         args: ["/tmp/sysbenchScript"]
-        image: "quay.io/cloud-bulldozer/sysbench:latest"
+        image: {{ sysbench.image | default('quay.io/cloud-bulldozer/sysbench:latest') }}
         imagePullPolicy: Always
         wait: true
         volumeMounts:
@@ -31,7 +31,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always

--- a/roles/uperf-bench/templates/server.yml.j2
+++ b/roles/uperf-bench/templates/server.yml.j2
@@ -17,7 +17,7 @@ spec:
 {% endif %}
   containers:
   - name: benchmark
-    image: "quay.io/cloud-bulldozer/uperf:latest"
+    image: {{ uperf.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
 {% if uperf.server_resources is defined %}
     resources: {{ uperf.server_resources | to_json }}
 {% endif %}
@@ -39,7 +39,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
   initContainers:
   - name: backpack-{{ trunc_uuid }}
-    image: quay.io/cloud-bulldozer/backpack:latest
+    image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
     command: ["/bin/sh", "-c"]
     args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
     imagePullPolicy: Always

--- a/roles/uperf-bench/templates/workload.yml.j2
+++ b/roles/uperf-bench/templates/workload.yml.j2
@@ -37,7 +37,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: benchmark
-        image: "quay.io/cloud-bulldozer/uperf:latest"
+        image: {{ uperf.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
 {% if uperf.client_resources is defined %}
         resources: {{ uperf.client_resources | to_json }}
 {% endif %}
@@ -112,7 +112,7 @@ spec:
 {% if metadata_collection|default(false) is sameas true and metadata_targeted|default(true) is sameas true %}
       initContainers:
       - name: backpack-{{ trunc_uuid }}
-        image: quay.io/cloud-bulldozer/backpack:latest
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
         command: ["/bin/sh", "-c"]
         args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name"]
         imagePullPolicy: Always


### PR DESCRIPTION
This adds an optional workload argument image which takes the image location. This is to make debugging and testing changes easier by allowing you to pass a different image location without having to rebuild the operator image.