### PR TITLE
Adding Cerberus integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ spec:
 ## Metadata Collection
 [Metadata Collection](docs/metadata.md)
 
+## Cerberus Integration
+[Cerberus Integration](docs/cerberus.md)
+
 ## Community
-Key Members(slack_usernames): aakarsh, dblack or rook
+Key Members(slack_usernames): aakarsh, dry923, rsevilla or rook
 * [**#sig-scalability on Kubernetes Slack**](https://kubernetes.slack.com)
 * [**#forum-kni-perfscale on CoreOS Slack**](https://coreos.slack.com)

--- a/docs/cerberus.md
+++ b/docs/cerberus.md
@@ -1,0 +1,60 @@
+# Cerberus Integration
+
+How To:
+* [What is it](#what-is-it)
+* [How it Works](#how-it-works)
+* [How to enable Cerberus](#how-to-enable-Cerberus)
+
+# What is it
+
+What is Cerberus? [Cerberus](https://github.com/openshift-scale/cerberus) is a project that will watch an Openshift/Kubernernetes cluster
+for dead nodes, component failures, etc and provide a healthly/unhealthy (True/False) signal. 
+
+# How it Works
+
+For installation and startup instructions for Cerberus please see [https://github.com/openshift-scale/cerberus](https://github.com/openshift-scale/cerberus)
+
+Ripsaw has been enabled to check a provided Cerberus url for a True/False signal. True being healthy and False being unhealthy (meaning a component
+has failed). If ripsaw encounters a False signal it will set the State of the benchmark to Error and the benchmark will not proceed
+further. 
+
+It will NOT stop any running components or kill any pods when a failure signal is found. That means that any pods that are running will
+continue to run. Ripsaw will simply not proceed to any next steps of the workload. Everything is left in this state to aid in any
+potential debugging that may need to be done.
+
+Once an Error state is entered it will not go back to its previous state. This means that you will either need to restart the benchmark
+entirely or manually change the state of the benchmark.
+
+# How to enable Cerberus
+
+Enabling Cerberus is very easy. Simply define the cerberus_url variable in your CR file with the url:port of the Cerberus service you wish
+to use.
+
+For example, if Cerberus is running at 1.2.3.4:8080
+
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: byowl-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: "foo.bar.com"
+    port: 9200
+  cerberus_url: "http://1.2.3.4:8080"
+  workload:
+    name: byowl
+...
+```
+
+NOTE: The cerberus url MUST BE in the format http://[address]:[port]
+
+Once Cerberus is enabled the connection status can be viewed by getting the benchmark status. If Cerberus is not
+enabled the connection status will simply be "not connected"
+
+```
+$ kubectl -n my-ripsaw get benchmarks.ripsaw.cloudbulldozer.io
+NAME              TYPE    STATE   METADATA STATE   CERBERUS    UUID                                   AGE
+byowl-benchmark   byowl   Error   Complete         Connected   11faec65-4009-58e8-ac36-0233f0fc822d   10m
+```

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,6 +2,14 @@
   gather_facts: no
   tasks:
 
+  - name: Get update from Cerberus if connected
+    block:
+    - include_role:
+        name: "cerberus"
+
+    when: cerberus_url is defined and cerberus_url != ""
+
+
   - name: Get state
     k8s_facts:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
@@ -38,8 +46,9 @@
           complete: false
           suuid: "{{ trunc_uuid }}"
           metadata: "not collected"
-
-    when: workload is defined and cr_state.resources[0].status is not defined
+          cerberus: "not connected"
+    
+    when: workload is defined and (cr_state.resources[0].status is not defined or cr_state.resources[0].status.uuid is not defined)
 
   - name: Run Workload
     block:
@@ -136,4 +145,4 @@
 
       when: metadata is not defined or not metadata.collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete") or metadata.targeted | default('true') | bool
     
-    when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool
+    when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool and (cr_state.resources[0].status.state is not defined or cr_state.resources[0].status.state != "Error")

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -40,13 +40,14 @@ spec:
               metadata:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
+              cerberus_url:
+                type: string
               cleanup:
                 type: boolean
               test_user: 
                 type: string
               clustername: 
                 type: string
-### I don't know if this one is needed but its in fs_drift
               es_index: 
                 type: string 
           status:
@@ -62,6 +63,8 @@ spec:
                 type: string
               uuid:
                 type: string
+              cerberus:
+                type: string
     additionalPrinterColumns:
     - name: Type
       type: string
@@ -75,6 +78,10 @@ spec:
       type: string
       description: The state of metadata collection
       jsonPath: .status.metadata
+    - name: Cerberus
+      type: string
+      description: If Cerberus is connected or not
+      jsonPath: .status.cerberus
     - name: UUID
       type: string
       jsonPath: .status.uuid

--- a/roles/cerberus/tasks/main.yml
+++ b/roles/cerberus/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Get status from Cerberus
+  uri:
+    url: "{{ cerberus_url }}"
+    return_content: yes
+  register: result
+
+- name: Update status if unhealthy
+  k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      cerberus: "Connected"
+      state: "Error"
+  when: result.content == "False"
+
+- name: Update status if healthy
+  k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      cerberus: "Connected"
+  when: result.content == "True"
+


### PR DESCRIPTION
This allows the user to pass a cerberus_url variable to ripsaw via the CR file. If provided it will set the benchmark status of Cerberus to connected. If Cerberus reports a failure during the lifecycle of the workload the benchamrk status will be set to Error and it will not proceed further. It will NOT kill any running pods or make any modifications to the cluster. It will just halt any further progress. 

Additionally, once an error state has been reached it will not be reset by ripsaw. The workload will need to either be restarted or you will need to set the state back to its previous value by hand.

Cerberus: https://github.com/openshift-scale/cerberus