### PR TITLE
Fixing incorrect indentation in backpack template

### DIFF
--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -32,7 +32,7 @@ spec:
         imagePullPolicy: Always
         wait: true
 {% if metadata is defined and metadata.privileged is defined %}
-       securityContext:
+        securityContext:
           privileged: {{ metadata.privileged | default(false) | bool }}
 {% endif %}
         readinessProbe:


### PR DESCRIPTION
During a PR 315 the spacing for securityContext got messed up. This resolves it.