### PR TITLE
Allow privileged for fio server pods

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -9,6 +9,8 @@ spec:
 #    port: 9200
 #  clustername: myk8scluster
 #  test_user: ripsaw
+# Run fio sever as privileged in order to be able to drop caches
+  privileged: true
   workload:
     name: "fio_distributed"
     args:
@@ -29,6 +31,10 @@ spec:
       read_ramp_time: 5
       filesize: 2GiB
       log_sample_rate: 1000
+#  NOTE: Dropping caches as per this example can only be done if the
+#        fio server is running in a privileged pod
+      global_overrides:
+        - exec_prerun=sync && echo 3 > /proc/sys/vm/drop_caches
       #storageclass: rook-ceph-block
       #storagesize: 5Gi
       #rook_ceph_drop_caches: True

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -46,6 +46,8 @@ spec:
                 type: string
               clustername: 
                 type: string
+              privileged:
+                type: boolean
 ### I don't know if this one is needed but its in fs_drift
               es_index: 
                 type: string 

--- a/roles/fio-distributed/templates/configmap.yml.j2
+++ b/roles/fio-distributed/templates/configmap.yml.j2
@@ -50,8 +50,8 @@ data:
 
     [{{job}}]
     rw={{job}}
-{% if global_overrides|default([])|length %}
-{% for override in global_overrides %}
+{% if fiod.global_overrides|default([])|length %}
+{% for override in fiod.global_overrides %}
     {{ override }}
 {% endfor %}
 {% endif %}

--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: fio-server
-{% if hostpath is defined %}
+{% if privileged|default(false, true) or hostpath is defined %}
         securityContext:
           privileged: true
 {% endif %}


### PR DESCRIPTION
Allow privileged fio server pods so we can drop caches using the fio parameter exec_prerun as mentioned at the updated documentation.