### PR TITLE
allow for pinning of ycsb load/workload pods

### DIFF
--- a/docs/ycsb.md
+++ b/docs/ycsb.md
@@ -30,6 +30,8 @@ spec:
         - workloadb
       options_load: '-p mongodb.url="mongodb://mongo/ycsb?"' #passed as is to ycsb when loading database
       options_run: '-p mongodb.url="mongodb://mongo/ycsb?" -threads 10 -target 100'
+      pin: false
+      #pin_node:
 ```
 
 The following options in args are required:
@@ -59,6 +61,11 @@ The following options are optional:
 
 `options_load` This needs to be set if `loaded` is not defined or set to false, and like in the case of `options_run` this needs to be configured properly,
 so that the ycsb pod can access the API of database.
+
+`pin` will allow the benchmark runner place nodes on specific nodes, using the `hostname` label.
+
+`pin_node` what node to pin the pod to.
+
 
 Once done creating/editing the resource file, you can run it by:
 

--- a/roles/load-ycsb/tasks/main.yml
+++ b/roles/load-ycsb/tasks/main.yml
@@ -9,55 +9,7 @@
 
 - name: Load Data Into Database
   k8s:
-    definition:
-      kind: Job
-      apiVersion: batch/v1
-      metadata:
-        name: 'ycsb-data-load-job-{{ ycsb_workload }}-{{ trunc_uuid }}'
-        namespace: '{{ operator_namespace }}'
-      spec:
-        template:
-          metadata:
-            name: '{{ meta.name }}-ycsb-data-load'
-            namespace: '{{ operator_namespace }}'
-            labels:
-             name: 'ycsb-load-{{ trunc_uuid }}'
-          spec:
-            containers:
-            - name: ycsb
-              image: "quay.io/cloud-bulldozer/ycsb-server:latest"
-              imagePullPolicy: Always
-              env:
-              - name: clustername
-                value: "{{ clustername }}"
-              - name: es
-                value: "{{elasticsearch.server | default()}}"
-              - name: es_port
-                value: "{{elasticsearch.port | default()}}"
-              - name: es_index
-                value: "{{ es_index }}"
-              - name: user
-                value: "{{test_user | default()}}"
-              - name: workload
-                value: "{{ycsb_workload}}"
-              - name: num_records
-                value: "{{ycsb.recordcount}}"
-              - name: num_operations
-                value: "{{ycsb.operationcount}}"
-              - name: uuid
-                value: "{{uuid}}"
-              imagePullPolicy: Always
-              command: ["/bin/sh", "-c"]
-              args: ["python /opt/snafu/run_snafu.py --tool ycsb -r 1 -l -d {{ ycsb.driver }} -u {{ uuid }} --user {{ test_user | default(\"ripsaw\") }} -w {{ ycsb_workload }} -x \"{{ ycsb.options_load }}\""]
-              volumeMounts:
-                - name: config-volume
-                  mountPath: "/tmp/ycsb"
-            restartPolicy: Never
-            volumes:
-            - name: config-volume
-              configMap:
-                name: ycsb-test-{{ trunc_uuid }}
-        backoffLimit: 4
+    definition: "{{ lookup('template', 'workload.yml.j2') }}"
 
 - name: Wait for Load Job to Succeed...
   k8s_facts:

--- a/roles/load-ycsb/templates/workload.yml.j2
+++ b/roles/load-ycsb/templates/workload.yml.j2
@@ -1,0 +1,52 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: 'ycsb-data-load-job-{{ ycsb_workload }}-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  template:
+    metadata:
+      name: '{{ meta.name }}-ycsb-data-load'
+      namespace: '{{ operator_namespace }}'
+      labels:
+        name: 'ycsb-load-{{ trunc_uuid }}'
+    spec:
+      containers:
+      - name: ycsb
+        image: "quay.io/cloud-bulldozer/ycsb-server:latest"
+        imagePullPolicy: Always
+        env:
+        - name: clustername
+          value: "{{ clustername }}"
+        - name: es
+          value: "{{ elasticsearch.server | default() }}"
+        - name: es_port
+          value: "{{ elasticsearch.port | default() }}"
+        - name: es_index
+          value: "{{ es_index }}"
+        - name: user
+          value: "{{ test_user | default() }}"
+        - name: workload
+          value: "{{ ycsb_workload }}"
+        - name: num_records
+          value: "{{ ycsb.recordcount }}"
+        - name: num_operations
+          value: "{{ ycsb.operationcount }}"
+        - name: uuid
+          value: "{{ uuid }}"
+        command: ["/bin/sh", "-c"]
+        args: ['python /opt/snafu/run_snafu.py --tool ycsb -r 1 -l -d {{ ycsb.driver }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -w {{ ycsb_workload }} -x "{{ ycsb.options_load }}"']
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/ycsb"
+{% if ycsb.pin|default(false) is sameas true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ ycsb.pin_node }}'
+{% endif %}
+      restartPolicy: OnFailure
+      volumes:
+      - name: config-volume
+        configMap:
+          name: ycsb-test-{{ trunc_uuid }}
+  backoffLimit: 4

--- a/roles/ycsb-bench/tasks/main.yml
+++ b/roles/ycsb-bench/tasks/main.yml
@@ -9,55 +9,7 @@
 
 - name: Run YCSB Workload
   k8s:
-    definition:
-      kind: Job
-      apiVersion: batch/v1
-      metadata:
-        name: 'ycsb-bench-job-{{ ycsb_workload }}-{{ trunc_uuid }}'
-        namespace: '{{ operator_namespace }}'
-      spec:
-        template:
-          metadata:
-            name: '{{ meta.name }}-ycsb-bench'
-            namespace: '{{ operator_namespace }}'
-            labels:
-              name: 'ycsb-run-{{ trunc_uuid }}'
-          spec:
-            containers:
-            - name: ycsb
-              image: "quay.io/cloud-bulldozer/ycsb-server:latest"
-              imagePullPolicy: Always
-              env:
-              - name: clustername
-                value: "{{ clustername }}"
-              - name: es
-                value: "{{elasticsearch.server | default()}}"
-              - name: es_port
-                value: "{{elasticsearch.port | default()}}"
-              - name: es_index
-                value: "{{ es_index }}"
-              - name: user
-                value: "{{test_user | default()}}"
-              - name: workload
-                value: "{{ycsb_workload}}"
-              - name: num_records
-                value: "{{ycsb.recordcount}}"
-              - name: num_operations
-                value: "{{ycsb.operationcount}}"
-              - name: uuid
-                value: "{{uuid}}"
-              imagePullPolicy: Always
-              command: ["/bin/sh", "-c"]
-              args: ["python /opt/snafu/run_snafu.py --tool ycsb -r 1 -d {{ ycsb.driver }} -w {{ ycsb_workload }} -u {{ uuid }} --user {{ test_user | default(\"ripsaw\") }} -x \"{{ ycsb.options_run }}\""]
-              volumeMounts:
-                - name: config-volume
-                  mountPath: "/tmp/ycsb"
-            restartPolicy: Never
-            volumes:
-              - name: config-volume
-                configMap:
-                  name: ycsb-test-{{ trunc_uuid }}
-        backoffLimit: 4
+    definition: "{{ lookup('template', 'workload.yml.j2') }}"
 
 - name: Wait for YCSB Workload Job to Succeed...
   k8s_facts:

--- a/roles/ycsb-bench/templates/workload.yml.j2
+++ b/roles/ycsb-bench/templates/workload.yml.j2
@@ -1,0 +1,52 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: 'ycsb-bench-job-{{ ycsb_workload }}-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  template:
+    metadata:
+      name: '{{ meta.name }}-ycsb-bench'
+      namespace: '{{ operator_namespace }}'
+      labels:
+        name: 'ycsb-run-{{ trunc_uuid }}'
+    spec:
+      containers:
+      - name: ycsb
+        image: "quay.io/cloud-bulldozer/ycsb-server:latest"
+        imagePullPolicy: Always
+        env:
+        - name: clustername
+          value: "{{ clustername }}"
+        - name: es
+          value: "{{ elasticsearch.server | default() }}"
+        - name: es_port
+          value: "{{ elasticsearch.port | default() }}"
+        - name: es_index
+          value: "{{ es_index }}"
+        - name: user
+          value: "{{ test_user | default() }}"
+        - name: workload
+          value: "{{ ycsb_workload }}"
+        - name: num_records
+          value: "{{ ycsb.recordcount }}"
+        - name: num_operations
+          value: "{{ ycsb.operationcount }}"
+        - name: uuid
+          value: "{{ uuid }}"
+        command: ["/bin/sh", "-c"]
+        args: ['python /opt/snafu/run_snafu.py --tool ycsb -r 1 -d {{ ycsb.driver }} -w {{ ycsb_workload }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -x "{{ ycsb.options_run }}"']
+        volumeMounts:
+          - name: config-volume
+            mountPath: "/tmp/ycsb"
+      restartPolicy: OnFailure
+{% if ycsb.pin_node is sameas true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ ycsb.pin_node }}'
+{% endif %}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ycsb-test-{{ trunc_uuid }}
+  backoffLimit: 4


### PR DESCRIPTION
This commit will facilitate pinning of the workload/load pods
to a specific nodes, and also in the process moves the pod/job
definition into ansible templates