### PR TITLE
allow fio servers to avoid nodes with a label

### DIFF
--- a/roles/fio-distributed/templates/servers.yaml
+++ b/roles/fio-distributed/templates/servers.yaml
@@ -12,6 +12,14 @@ spec:
         app: fio-benchmark-{{ trunc_uuid }}
     spec:
       affinity:
+{% if fiod.avoidlabel is defined %}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            matchExpressions:
+            - key: {{ fiod.avoidlabel }}
+              operator: DoesNotExist
+{% endif %}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100


### PR DESCRIPTION
Do not merge yet, this is more of an idea at this point, but I just tried fio in a cluster with 31 workers an d 16 OCS nodes, ripsaw fio deployed 30 pods across 30 nodes including the OCS nodes, which is a real problem for performance.    We want it to use the other workers.   I structured this change so that it is not OCS specific - it will place fio-server pods on any worker **other than** the nodes with the specified label.