### PR TITLE
shorten both of these tests up so CI doesn't timeout

### DIFF
--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -23,9 +23,7 @@ spec:
         - randrw
       bs:
         - 4KiB
-        - 64KiB
       numjobs:
-        - 1
         - 2
       iodepth: 1
       read_runtime: 10

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -14,7 +14,7 @@ spec:
   workload:
     name: "fio_distributed"
     args:
-      samples: 2
+      samples: 1
       servers: 2
       prefill: true
       jobs:
@@ -25,7 +25,6 @@ spec:
         - randrw
       bs:
         - 4KiB
-        - 64KiB
       numjobs:
         - 1
         - 2


### PR DESCRIPTION
cut down on number of I/O sizes and numjobs values for valid_fiod
cut down on samples and number of I/O sizes for valid_fiod_hostpath
tested with minikube - I was able to reproduce the timeout before this fix.  With this fix I tested it twice and no timeout occurred.