### PR TITLE
Refresh ES index before checking for documents

### DIFF
--- a/tests/check_es.py
+++ b/tests/check_es.py
@@ -28,6 +28,7 @@ def _check_index(server,port,uuid,index,es_ssl):
                                                  ssl_context=ssl_ctx, use_ssl=True)
     else:
         es = elasticsearch.Elasticsearch([_es_connection_string], send_get_body_as='POST')
+    es.indices.refresh(index=index)
     results = es.search(index=index, body={'query': {'term': {'uuid.keyword': uuid}}}, size=1)
     if results['hits']['total']['value'] > 0:
         return 0

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -46,18 +46,7 @@ function populate_test_list {
 }
 
 function wait_clean {
-  kubectl delete benchmark --all -n my-ripsaw
-  kubectl delete all --all -n my-ripsaw
-  for i in {1..30}; do
-    if [ `kubectl get pods --namespace my-ripsaw | grep bench | wc -l` -ge 1 ]; then
-      sleep 5
-    else
-      break
-    fi
-  done
-  if [[ `kubectl get namespace my-ripsaw` ]]; then
-    kubectl delete namespace my-ripsaw
-  fi
+  kubectl delete namespace my-ripsaw --ignore-not-found
 }
 
 # The argument is 'timeout in seconds'

--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -18,7 +18,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_backpack {
-  figlet $(basename $0)
+  wait_clean
   apply_operator
   kubectl apply -f tests/test_crs/valid_backpack.yaml
   long_uuid=$(get_uuid 20)
@@ -34,9 +34,10 @@ function functional_test_backpack {
   then
     echo "Backpack test: Success"
   else
+    echo "Failed to find data in ES"
     exit 1
-    echo "Faled to find data in ES"
   fi
 }
 
+figlet $(basename $0)
 functional_test_backpack

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -18,7 +18,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_byowl {
-  figlet $(basename $0)
+  wait_clean
   apply_operator
   kubectl apply -f tests/test_crs/valid_byowl.yaml
   long_uuid=$(get_uuid 20)
@@ -31,4 +31,5 @@ function functional_test_byowl {
   echo "BYOWL test: Success"
 }
 
+figlet $(basename $0)
 functional_test_byowl

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -17,6 +17,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_fio {
+  wait_clean
   apply_operator
   test_name=$1
   cr=$2
@@ -30,21 +31,18 @@ function functional_test_fio {
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=500s" "500s" $fio_pod
   wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs -n my-ripsaw --timeout=500s" "500s" $fio_pod
-  # ensuring the run has actually happened
-  kubectl logs "$fio_pod" -n my-ripsaw
-  kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
 
-  index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
-  if check_es "${long_uuid}" "${index}"
+  indexes="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
+  if check_es "${long_uuid}" "${indexes}"
   then
     echo "${test_name} test: Success"
   else
     echo "Failed to find data for ${test_name} in ES"
+    kubectl logs "$fio_pod" -n my-ripsaw
     exit 1
   fi
 }
 
 figlet $(basename $0)
 functional_test_fio "Fio distributed" tests/test_crs/valid_fiod.yaml
-wait_clean
 functional_test_fio "Fio hostpath distributed" tests/test_crs/valid_fiod_hostpath.yaml

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -18,7 +18,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_iperf {
-  figlet $(basename $0)
+  wait_clean
   apply_operator
   kubectl apply -f tests/test_crs/valid_iperf3.yaml
   long_uuid=$(get_uuid 20)
@@ -35,4 +35,5 @@ function functional_test_iperf {
   echo "iperf test: Success"
 }
 
+figlet $(basename $0)
 functional_test_iperf

--- a/tests/test_sysbench.sh
+++ b/tests/test_sysbench.sh
@@ -18,7 +18,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_sysbench {
-  figlet $(basename $0)
+  wait_clean
   apply_operator
   kubectl apply -f tests/test_crs/valid_sysbench.yaml
   long_uuid=$(get_uuid 20)
@@ -34,4 +34,5 @@ function functional_test_sysbench {
   echo "Sysbench test: Success"
 }
 
+figlet $(basename $0)
 functional_test_sysbench

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -17,6 +17,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_uperf {
+  wait_clean
   apply_operator
   test_name=$1
   cr=$2
@@ -31,9 +32,6 @@ function functional_test_uperf {
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 900)
   wait_for "kubectl wait -n my-ripsaw --for=condition=Initialized pods/$uperf_client_pod --timeout=500s" "500s" $uperf_client_pod
   wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=500s" "500s" $uperf_client_pod
-  # ensuring that uperf actually ran and we can access metrics
-  kubectl logs "$uperf_client_pod" -n my-ripsaw
-  kubectl logs "$uperf_client_pod" -n my-ripsaw | grep Success
 
   index="ripsaw-uperf-results"
   if check_es "${long_uuid}" "${index}"
@@ -41,13 +39,12 @@ function functional_test_uperf {
     echo "${test_name} test: Success"
   else
     echo "Failed to find data for ${test_name} in ES"
+    kubectl logs "$uperf_client_pod" -n my-ripsaw
     exit 1
   fi
 }
 
 figlet $(basename $0)
 functional_test_uperf "Uperf without resources definition" tests/test_crs/valid_uperf.yaml
-wait_clean
 functional_test_uperf "Uperf with ServiceIP" tests/test_crs/valid_uperf_serviceip.yaml
-wait_clean
 functional_test_uperf "Uperf with resources definition" tests/test_crs/valid_uperf_resources.yaml

--- a/tests/test_uperf_serviceip.sh
+++ b/tests/test_uperf_serviceip.sh
@@ -18,7 +18,7 @@ trap error ERR
 trap finish EXIT
 
 function functional_test_uperf_serviceip {
-  figlet $(basename $0)
+  wait_clean
   apply_operator
   kubectl apply -f tests/test_crs/valid_uperf_serviceip.yaml
   uuid=$(get_uuid 20)
@@ -36,4 +36,6 @@ function functional_test_uperf_serviceip {
   kubectl logs "$uperf_client_pod" --namespace my-ripsaw | grep Success
   echo "Uperf test: Success"
 }
+
+figlet $(basename $0)
 functional_test_uperf_serviceip


### PR DESCRIPTION
There are situations where check_es.py script is not able to find documents on ES. This PR updates that script to refresh the index prior to query it.
In addition, it also standardizes some of the CI code and simplifies the wait_clean function.