### PR TITLE
migrate  to ansible-operator:v0.17.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,10 +1,18 @@
-FROM quay.io/operator-framework/ansible-operator:v0.8.1
+FROM quay.io/operator-framework/ansible-operator:v0.17.0
+
+COPY requirements.yml ${HOME}/requirements.yml
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
+
+USER root
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
+
+# Temporally workaround to fix https://github.com/operator-framework/operator-sdk/issues/2648
+RUN ln -s ${HOME}/.ansible /.ansible
 
 COPY group_vars/ ${HOME}/group_vars/
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY playbook.yml ${HOME}/playbook.yml
-
-USER root
-RUN yum install -y redis
 USER 1001

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,0 +1,5 @@
+[centos8-appstream]
+name=CentOS-8-Appstream
+baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+enabled=0
+gpgcheck=0

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,7 +36,7 @@
         name: "uuid"
 
     - name: Setting the uuid for the benchmark
-      k8s_status:
+      operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
@@ -63,7 +63,7 @@
           name: backpack
         when: metadata is defined and not metadata.targeted | default('true') | bool
 
-      - k8s_status:
+      - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
           name: "{{ meta.name }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.kubernetes
+    version: "<1.0.0"
+  - operator_sdk.util

--- a/roles/backpack/tasks/main.yml
+++ b/roles/backpack/tasks/main.yml
@@ -7,7 +7,7 @@
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -58,7 +58,7 @@
     set_fact:
       backpack_cur_gen: "{{ my_daemonset | json_query('resources[].metadata.generation')|first }}"
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -89,7 +89,7 @@
     
     - block:
 
-      - k8s_status:
+      - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
           name: "{{ meta.name }}"

--- a/roles/byowl/tasks/main.yml
+++ b/roles/byowl/tasks/main.yml
@@ -8,7 +8,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -34,7 +34,7 @@
       definition: "{{ lookup('template', 'workload.yml') | from_yaml }}"
     when: workload_args.kind is not defined
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -56,7 +56,7 @@
         - app = byowl-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/cerberus/tasks/main.yml
+++ b/roles/cerberus/tasks/main.yml
@@ -6,7 +6,7 @@
   register: result
 
 - name: Update status if unhealthy
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -17,7 +17,7 @@
   when: result.content == "False"
 
 - name: Update status if healthy
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -7,7 +7,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -59,7 +59,7 @@
     with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
     when: workload_args.storageclass is defined
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -87,7 +87,7 @@
         - app = fio-benchmark-{{ trunc_uuid }}
     register: server_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -119,7 +119,7 @@
   - name: Create IP list
     set_fact:
       fio_hosts: |
-         {% for ip, node in pod_details.iteritems() %}
+         {% for ip, node in pod_details.items() %}
          {{ ip }}
          {% endfor %}
 
@@ -139,7 +139,7 @@
     k8s:
       definition: "{{ lookup('template', 'client.yaml') | from_yaml }}"
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -160,7 +160,7 @@
         - app = fiod-client-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/fs-drift/tasks/main.yml
+++ b/roles/fs-drift/tasks/main.yml
@@ -8,7 +8,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -116,7 +116,7 @@
     with_sequence: start=1 count={{workload_args.worker_pods|default('1')|int}}
     when: workload_args.worker_pods|default('1')|int > 0
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -138,7 +138,7 @@
         - app = fs-drift-benchmark-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/iperf3/tasks/main.yml
+++ b/roles/iperf3/tasks/main.yml
@@ -7,7 +7,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -33,7 +33,7 @@
     with_sequence: start=1 count={{ workload_args.pairs|default('1')|int }}
 
   - name: Update state to Starting Server
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -55,7 +55,7 @@
     register: server_pods
 
   - name: Update state to Starting Clients
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -83,7 +83,7 @@
     with_items: "{{ server_pods.resources }}"
 
   - name: Update state to Waiting for Clients
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -104,7 +104,7 @@
         - app = iperf3-bench-client-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -126,7 +126,7 @@
         - app = iperf3-bench-client-{{ trunc_uuid }}
     register: client_jobs
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/pgbench/tasks/check_clients.yml
+++ b/roles/pgbench/tasks/check_clients.yml
@@ -3,7 +3,7 @@
   shell: "redis-cli --raw llen pgb_client_ready"
   register: client_ready
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/pgbench/tasks/init.yml
+++ b/roles/pgbench/tasks/init.yml
@@ -2,7 +2,7 @@
 - name: Initialize dbnum_item in redis
   command: "redis-cli set dbnum_item 0"
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/pgbench/tasks/main.yml
+++ b/roles/pgbench/tasks/main.yml
@@ -7,7 +7,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/pgbench/tasks/prep_workload.yml
+++ b/roles/pgbench/tasks/prep_workload.yml
@@ -11,7 +11,7 @@
   with_indexed_items: "{{ workload_args.databases }}"
   when: item.0|int in range(dbnum|int)
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/pgbench/tasks/run_workload.yml
+++ b/roles/pgbench/tasks/run_workload.yml
@@ -15,7 +15,7 @@
   command: "redis-cli incr dbnum_item"
   when: "'Succeeded' in (pgbench_pods | json_query('resources[].status.phase'))"
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -25,7 +25,7 @@
       complete: false
   when: "'Succeeded' in (pgbench_pods | json_query('resources[].status.phase')) and dbnum_item|int < (num_databases|length - 1)"
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"

--- a/roles/smallfile/tasks/main.yml
+++ b/roles/smallfile/tasks/main.yml
@@ -8,7 +8,7 @@
   register: resource_state
 
 - name: Update current state
-  k8s_status:
+  operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -117,7 +117,7 @@
     with_sequence: start=1 count={{ workload_args.clients|default('1')|int }}
     when: workload_args.clients|default('1')|int > 0
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -139,7 +139,7 @@
         - app = smallfile-benchmark-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/sysbench/tasks/main.yml
+++ b/roles/sysbench/tasks/main.yml
@@ -8,7 +8,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -50,7 +50,7 @@
       definition: "{{ lookup('template', 'workload_vm.yml') | from_yaml }}"
     when:  workload_args.kind is defined and workload_args.kind == "vm"
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -72,7 +72,7 @@
         - app = sysbench-{{ trunc_uuid }}
     register: client_pods
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/sysbench/templates/sysbench.sh.j2
+++ b/roles/sysbench/templates/sysbench.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 {% for test in workload_args.tests %}
 {% if test.name == "cpu" or test.name == "memory" %}
-sysbench --test={{test.name}} {% for opt,value in test.parameters.iteritems() %} --{{opt}}={{value}} {% endfor %} run
+sysbench --test={{test.name}} {% for opt,value in test.parameters.items() %} --{{opt}}={{value}} {% endfor %} run
 {% elif test.name == "fileio" %}
 {% if 'file-total-size' not in test.parameters %}
 {% set dummy = test['parameters'].__setitem__("file-total-size", "1G") %}

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -8,7 +8,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -69,7 +69,7 @@
     register: server_pods
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -97,7 +97,7 @@
     register: server_vms
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -119,7 +119,7 @@
     register: server_pods
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -143,7 +143,7 @@
     register: server_vms
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -214,7 +214,7 @@
 
     when: resource_kind == "vm"
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -237,7 +237,7 @@
       register: client_pods
 
     - name: Update resource state
-      k8s_status:
+      operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
@@ -263,7 +263,7 @@
       register: client_vms
 
     - name: Update resource state
-      k8s_status:
+      operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
@@ -282,7 +282,7 @@
     command: "redis-cli set start true"
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -303,7 +303,7 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_pods
 
-    - k8s_status:
+    - operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
@@ -320,7 +320,7 @@
       command: "redis-cli get complete"
       register: complete_status
 
-    - k8s_status:
+    - operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
         name: "{{ meta.name }}"
@@ -365,7 +365,7 @@
       when: cleanup
     when: resource_kind == "pod"
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"

--- a/roles/ycsb/tasks/main.yml
+++ b/roles/ycsb/tasks/main.yml
@@ -7,7 +7,7 @@
     namespace: "{{ operator_namespace }}"
   register: resource_state
 
-- k8s_status:
+- operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: "{{ meta.name }}"
@@ -41,7 +41,7 @@
     when: workload_args.loaded is undefined or not workload_args.loaded
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -51,7 +51,7 @@
     when: workload_args.loaded is undefined or not workload_args.loaded|default('false')
   
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -79,7 +79,7 @@
     register: ycsb_load_pod
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -89,7 +89,7 @@
     when: "ycsb_load_pod | json_query('resources[].status.succeeded')"
  
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -109,7 +109,7 @@
     command: "redis-cli set {{ meta.name }}-{{ uuid }}-ycsb-current 0"
     
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -138,7 +138,7 @@
       definition: "{{ lookup('template', 'ycsb_run.yaml') | from_yaml }}"
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -169,7 +169,7 @@
     register: ycsb_bench
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -198,7 +198,7 @@
     command: "redis-cli set {{ meta.name }}-{{ uuid }}-ycsb-current {{ new_workload_index }}"
   
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"
@@ -208,7 +208,7 @@
     when: workload_list.stdout != new_workload_index
 
   - name: Update resource state
-    k8s_status:
+    operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
       name: "{{ meta.name }}"


### PR DESCRIPTION
This new version is based in ubi8 and uses python-3.6 and ansible-2.9.6
k8s_status module is no longer available and has been renamed to  operator_sdk.util.k8s_status since now is provided by an Ansible collection.