### PR TITLE
Adding additional check for scc in CI testing

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -169,8 +169,11 @@ function backpack_requirements {
   kubectl apply -f resources/backpack_role.yaml
   if [[ `command -v oc` ]]
   then
-    oc adm policy -n my-ripsaw add-scc-to-user privileged -z benchmark-operator
-    oc adm policy -n my-ripsaw add-scc-to-user privileged -z backpack-view
+    if [[ `oc get securitycontextconstraints.security.openshift.io` ]]
+    then
+      oc adm policy -n my-ripsaw add-scc-to-user privileged -z benchmark-operator
+      oc adm policy -n my-ripsaw add-scc-to-user privileged -z backpack-view
+    fi
   fi
 }
 


### PR DESCRIPTION
This would cause a CI failure previously if the oc command was installed but securitycontextconstraints.security.openshift.io did not exist. This is the case in minikube if the user also installed oc.