### PR TITLE
SDK update

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,16 @@
-FROM quay.io/operator-framework/ansible-operator:v0.17.0
+FROM quay.io/operator-framework/ansible-operator:v0.17.1
+USER root
 
 COPY requirements.yml ${HOME}/requirements.yml
-COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
-USER root
-RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
-
-# Temporally workaround to fix https://github.com/operator-framework/operator-sdk/issues/2648
-RUN ln -s ${HOME}/.ansible /.ansible
+RUN rpm --nodeps -i http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-repos-8.1-1.1911.0.9.el8.x86_64.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.1-1.1911.0.7.el8.noarch.rpm
+RUN dnf install -y --nodocs redis && dnf clean all
 
 COPY group_vars/ ${HOME}/group_vars/
 COPY roles/ ${HOME}/roles/
+COPY meta/ ${HOME}/meta/
 COPY watches.yaml ${HOME}/watches.yaml
 COPY playbook.yml ${HOME}/playbook.yml
 USER 1001

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,5 +1,0 @@
-[centos8-appstream]
-name=CentOS-8-Appstream
-baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-enabled=0
-gpgcheck=0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+collections:
+- community.kubernetes
+- operator_sdk.util

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,4 +1,6 @@
 - hosts: localhost
+  collections:
+   - operator_sdk.util
   gather_facts: no
   tasks:
 


### PR DESCRIPTION
Update Operator framework from 0.17.0 to 0.17.1

I initially did this from 0.8.1 to 0.17.1 but @rsevilla87 was quicker to push this to master :laughing: 
This is now based on ubi8 - thus we need the CentOS AppStream to install redis

https://github.com/operator-framework/operator-sdk/issues/2648