### PR TITLE
Fio in vms

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a performance baseline of Kubernetes cluster on your provider.
 | ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- |
 | [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Preview               |
 | [Iperf3](docs/iperf3.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported         |
-| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Not Supported         |
+| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Working               |
 | [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported         |
 | [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported         |
 | [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported         |

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -33,6 +33,10 @@ spec:
       samples: 3
       servers: 3
       pin_server: ''
+      # Chose to run servers in 'pod' or 'vm'
+      # 'vm' needs kubevirt to be available
+      # Default: pod
+      kind: pod
       jobs:
         - write
         - read
@@ -109,6 +113,7 @@ The workload loops are nested as such from the CR options:
 ```
 
 ### Understanding the CR options
+
 >**A note about units:**
 >
 > For consistency in the CR file, we apply the fio option `kb_base=1000` in the jobfile configmap. The
@@ -117,7 +122,7 @@ The workload loops are nested as such from the CR options:
 > (1KiB = 1024B).
 >
 > However, note that fio (as of versions we have tested) does not react as might be expected to "shorthand"
-> IEC units like `Ki` or `Mi` -- these will be treated as base-10 instead of base-2. 
+> IEC units like `Ki` or `Mi` -- these will be treated as base-10 instead of base-2.
 >
 > Unfortunately, the [K8S resource model](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md)
 > specifies [explicitly](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities)
@@ -128,54 +133,72 @@ The workload loops are nested as such from the CR options:
 > while the `storagesize` option used for the K8S persistent volume claim should use the `Mi` format
 
 #### metadata
+
 *Values here will usually be left unchanged*
+
 - **name**: The name the Ripsaw operator will use for the benchmark resource
 - **namespace**: The namespace in which the benchmark will run
 
 #### spec
+
 - **elasticsearch**: (optional) Values are used to enable indexing of fio data; [further details are below](#indexing-in-elasticsearch-and-visualization-through-grafana)
 - **clustername**: (optional) An arbitrary name for your system under test (SUT) that can aid indexing
 - **test_user**: (optional) An arbitrary name for the user performing the tests that can aid indexing
 
 #### spec.workload
+
 - **name**: **DO NOT CHANGE** This value is used by the Ripsaw operator to trigger the correct Ansible role
 
 #### spec.workload.args
+
 *This is the meat of the workload where most of the adjustments to your needs will be made.*
+
 - **samples**: Number of times to run the exact same workload. This is the innermost loop, as [described above](#workload-loops)
 - **servers**: Number of fio servers that will run the specified workload concurrently
 - **pin_server**: K8S node name (per `kubectl get nodes`) on which to run server pods
-> Note: Providing a node name to `pin_server` will result in *all* server pods running on the specified node.
+  > Note: Providing a node name to `pin_server` will result in *all* server pods running on the specified node.
 - **jobs**: (list) fio job types to run, per `fio(1)` valid values for the `readwrite` option
-> Note: Under most circumstances, a `write` job should be provided as the first list item for `jobs`. This will
-> ensure that subsequent jobs in the list can use the files created by the `write` job instead of needing
-> to instantiate the files themselves prior to beginning the benchmark workload.
+  > Note: Under most circumstances, a `write` job should be provided as the first list item for `jobs`. This will
+  > ensure that subsequent jobs in the list can use the files created by the `write` job instead of needing
+  > to instantiate the files themselves prior to beginning the benchmark workload.
+- **kind**: Can either be `pod` or `vm` to determine if the fio workload is run in a Pod or in a VM
+  > Note: For VM workloads, you need to install Openshift Virtualization first
+- **vm_image**: Whether to use a pre-defined VM image with pre-installed requirements. Necessary for disconnected installs.
+  > Note: You can use my fedora image here: quay.io/mulbc/fed-fio \
+  > Note: Only applies when kind is set to `vm`
+- **vm_cores**: The number of CPU cores that will be available inside the VM. Default=1
+  > Note: Only applies when kind is set to `vm`
+- **vm_cores**: The amount of Memory that will be available inside the VM in Kubernetes format. Default=5G
+  > Note: Only applies when kind is set to `vm`
 - **bs**: (list) blocksize values to use for I/O transactions
-> Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bs` values
-> provided here should be a multiple of the filesystem blocksize (typically 4KiB). The [note above about units](#understanding-the-cr-options)
-> applies here.
+  > Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bs` values
+  > provided here should be a multiple of the filesystem blocksize (typically 4KiB). The [note above about units](#understanding-the-cr-options)
+  > applies here.
 - **numjobs**: (list) Number of clones of the job to run on each server -- Total jobs will be `numjobs * servers`
 - **iodepth**: Number of I/O units to keep in flight against a file; see `fio(1)`
 - **read_runtime**: Amount of time in seconds to run `read` workloads (including `readwrite` workloads)
 - **read_ramp_time**: Amount of time in seconds to ramp up `read` workloads (i.e., executing the workload without recording the data)
-> Note: We intentionally run `write` workloads to completion of the file size specified in order to ensure
-> that complete files are available for subsequent `read` workloads. All `read` workloads are time-based,
-> using these parameters, but note this behavious is configured via the EXPERT AREA section of the CR as
-> [described below](#expert-specjob_params), and therefore this may be adjusted to user preferences.
+  > Note: We intentionally run `write` workloads to completion of the file size specified in order to ensure
+  > that complete files are available for subsequent `read` workloads. All `read` workloads are time-based,
+  > using these parameters, but note this behavious is configured via the EXPERT AREA section of the CR as
+  > [described below](#expert-specjob_params), and therefore this may be adjusted to user preferences.
 - **filesize**: The size of the file used for each job in the workload (per `numjobs * servers` as described above)
 - **log_sample_rate**: Applied to fio options `log_avg_msec` and `log_hist_msec` in the jobfile configmap; see `fio(1)`
 - **storageclass**: (optional) The K8S StorageClass to use for persistent volume claims (PVC) per server pod
 - **storagesize**: (optional) The size of the PVCs to request from the StorageClass ([note units quirk per above](#understanding-the-cr-options))
 - **rook_ceph_drop_caches**: (optional) If set to `True`, the Rook-Ceph OSD caches will be dropped prior to each sample
 - **rook_ceph_drop_cache_pod_ip**: (optional) The IP address of the pod hosting the Rook-Ceph cache drop URL -- See [cache drop pod instructions](#dropping-rook-ceph-osd-caches) below
-> Technical Note: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.
-- **prefill**: (Optional) boolean to enable/disable prefill SDS <br />
---  prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
+  > Technical Note: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.
+- **prefill**: (Optional) boolean to enable/disable prefill SDS
+  - prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
+
 #### EXPERT: spec.global_overrides
+
 The `key=value` combinations provided in the list here will be appended to the `[global]` section of the fio
 jobfile configmap. These options will therefore override the global values for all workloads in the loop.
 
 #### EXPERT: spec.job_params
+
 Under most circumstances, the options provided in the EXPERT AREA here should not be modified. The `key=value`
 pairs under `params` here are used to append additional fio job options based on the job type. Each `jobname_match` in the list uses a "search string" to match a job name per `fio(1)`, and if a match is made, the `key=value` list items under `params` are appended to the `[job]` section of the fio jobfile configmap.
 
@@ -220,7 +243,6 @@ Once you have verified that you can access the elasticsearch, you'll have to cre
 We send fio logs to the index `ripsaw-fio-logs`, the template can be found in [arsenal](https://github.com/cloud-bulldozer/arsenal/blob/master/fio-distributed/elasticsearch/7.0.1/fio-logs.json).
 
 Ripsaw will be indexing the fio result json to the index `ripsaw-fio-result`. For this, no template is required. However if you're an advanced user of elasticsearch, you can create it and edit its settings.
-
 
 #### Grafana
 

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
@@ -1,0 +1,114 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: fio-vm-benchmark
+  namespace: my-ripsaw
+spec:
+#  elasticsearch:
+#    server: <es_server>
+#    port: 9200
+#  clustername: myk8scluster
+#  test_user: ripsaw
+  workload:
+    name: "fio_distributed"
+    args:
+      # if true, do large sequential write to preallocate volume before using
+      prefill: true
+      # number of times each test
+      samples: 3
+      # number of fio pods generating workload
+      servers: 3
+      # put all fio pods on this server
+      pin_server: ''
+      # Run fio servers in VMs
+      kind: vm
+      # Specify kubevirt registry image for server vm
+      # This is helpful in disconnected environments and we assume
+      # this VM image has all requirements already present
+      vm_image: quay.io/mulbc/fed-fio
+      # CPU cores that will be available inside the VM
+      # Default: 1
+      # vm_cores: 2
+      # Memory that will be available inside the VM
+      # Default: 5G
+      # vm_cores: 10G
+      # test types, see fio documentation
+      jobs:
+        - write
+        - read
+        - randwrite
+        - randread
+      # I/O request sizes (also called block size)
+      bs:
+        - 4k
+        - 64k
+      # how many fio processes per pod
+      numjobs:
+        - 1
+      # with libaio ioengine, number of in-flight requests per process
+      iodepth: 4
+      # how long to run write tests, this is TOO SHORT DURATION
+      read_runtime: 15
+      # how long to run read tests, this is TOO SHORT DURATION
+      write_runtime: 15
+      # don't start measuring until this many seconds pass, for reads
+      read_ramp_time: 5
+      # don't start measuring until this many seconds pass, for writes
+      write_ramp_time: 5
+      # size of file to access
+      filesize: 2GiB
+      # interval between i/o stat samples in milliseconds
+      log_sample_rate: 3000
+      storageclass: ocs-storagecluster-ceph-rbd
+      storagesize: 5Gi
+      #rook_ceph_drop_caches: True
+      #rook_ceph_drop_cache_pod_ip: 192.168.111.20
+#######################################
+#  EXPERT AREA - MODIFY WITH CAUTION  #
+#######################################
+#  global_overrides:
+#  NOTE: Dropping caches as per this example can only be done if the
+#        fio server is running in a privileged pod
+#    - exec_prerun=bash -c 'sync && echo 3 > /proc/sys/vm/drop_caches'
+  job_params:
+    - jobname_match: write
+      params:
+        - fsync_on_close=1
+        - create_on_open=1
+        - runtime={{workload_args.write_runtime }}
+        - ramp_time={{workload_args.write_ramp_time }}
+    - jobname_match: read
+      params:
+        - time_based=1
+        - runtime={{workload_args.read_runtime }}
+        - ramp_time={{workload_args.read_ramp_time }}
+    - jobname_match: rw
+      params:
+        - rwmixread=50
+        - time_based=1
+        - runtime={{workload_args.read_runtime }}
+        - ramp_time={{workload_args.read_ramp_time }}
+    - jobname_match: readwrite
+      params:
+        - rwmixread=50
+        - time_based=1
+        - runtime={{workload_args.read_runtime }}
+        - ramp_time={{workload_args.read_ramp_time }}
+    - jobname_match: randread
+      params:
+        - time_based=1
+        - runtime={{workload_args.read_runtime }}
+        - ramp_time={{workload_args.read_ramp_time }}
+    - jobname_match: randwrite
+      params:
+        - time_based=1
+        - runtime={{workload_args.write_runtime }}
+        - ramp_time={{workload_args.write_ramp_time }}
+    - jobname_match: randrw
+      params:
+        - time_based=1
+        - runtime={{workload_args.write_runtime }}
+        - ramp_time={{workload_args.write_ramp_time }}
+#    - jobname_match: <search_string>
+#      params:
+#        - key=value

--- a/roles/fio_distributed/defaults/main.yml
+++ b/roles/fio_distributed/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+resource_kind: "{{ workload.args.kind | default('pod') }}"

--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get current state
-  k8s_facts:
+  k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: '{{ meta.name }}'
@@ -18,7 +18,7 @@
   when: resource_state.resources[0].status.state is not defined
 
 - name: Get current state - If it has changed
-  k8s_facts:
+  k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
     name: '{{ meta.name }}'
@@ -59,6 +59,18 @@
     with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
     when: workload_args.storageclass is defined
 
+  - name: Start FIO Server(s)
+    k8s:
+      definition: "{{ lookup('template', 'servers.yaml') | from_yaml }}"
+    when: workload_args.servers|default('1')|int > 0 and (workload.args.kind | default('pod')) == "pod"
+    with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
+
+  - name: Start FIO Server(s) VM
+    k8s:
+      definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
+    when: workload_args.servers|default('1')|int > 0 and (workload.args.kind | default('pod')) == "vm"
+    with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
+
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -68,18 +80,12 @@
         state: StartingServers
         complete: false
 
-  - name: Start FIO Server(s)
-    k8s:
-      definition: "{{ lookup('template', 'servers.yaml') | from_yaml }}"
-    when: workload_args.servers|default('1')|int > 0
-    with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
-
   when: resource_state.resources[0].status.state == "Building"
 
 - block :
 
   - name: Capture pod list
-    k8s_facts:
+    k8s_info:
       kind: Pod
       api_version: v1
       namespace: '{{ operator_namespace }}'
@@ -95,33 +101,44 @@
       status:
         state: StartingClient
         complete: false
-    when : "workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status.podIP')|length) and workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length)"
-
-  when: resource_state.resources[0].status.state == "StartingServers"
-
-- block:
-
-  - name: Capture updated pod list
-    k8s_facts:
-      kind: Pod
-      api_version: v1
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - app = fio-benchmark-{{ trunc_uuid }}
-    register: server_pods
+    when : "workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status.podIP')|length) and workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length) and resource_state.resources[0].status.state == 'StartingServers'"
 
   - name: Create IP list and nodes
     set_fact:
       pod_details: "{{ pod_details|default({}) | combine({item.status.podIP: item.spec.nodeName}) }}"
     with_items: "{{ server_pods.resources }}"
 
-  # can perhaps optimize here, by adding to list in above loop
-  - name: Create IP list
+  when: (workload.args.kind | default('pod')) == "pod"
+
+- block :
+
+  - name: Capture pod list
+    k8s_info:
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = fio-benchmark-{{ trunc_uuid }}
+    register: server_pods
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: StartingClient
+        complete: false
+    when : "workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status.interfaces[].ipAddress')|length) and workload_args.servers|default('1')|int == (server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length) and resource_state.resources[0].status.state == 'StartingServers'"
+
+  - name: Create IP list and nodes
     set_fact:
-      fio_hosts: |
-         {% for ip, node in pod_details.items() %}
-         {{ ip }}
-         {% endfor %}
+      pod_details: "{{ pod_details|default({}) | combine({item.status.interfaces[0].ipAddress: item.status.nodeName}) }}"
+    with_items: "{{ server_pods.resources }}"
+
+  when: (workload.args.kind | default('pod')) == "vm"
+
+- block:
 
   - name: Generate fio hosts
     k8s:
@@ -133,7 +150,9 @@
           namespace: '{{ operator_namespace }}'
         data:
           hosts: |
-            {{ fio_hosts }}
+            {% for ip in pod_details.keys() %}
+            {{ ip }}
+            {% endfor %}
 
   - name: Start FIO Client
     k8s:
@@ -152,7 +171,7 @@
 
 - block:
   - name: Capture Client pod list
-    k8s_facts:
+    k8s_info:
       kind: Pod
       api_version: v1
       namespace: '{{ operator_namespace }}'

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -31,6 +31,8 @@ spec:
             value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.cert_verify | default("true") }}"
 {% endif %}
         command: ["/bin/sh", "-c"]
         args:

--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -1,0 +1,70 @@
+---
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: 'fio-server-{{item | string}}-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+  labels:
+    app: fio-benchmark-{{ trunc_uuid }}
+spec:
+  domain:
+    cpu:
+      cores: {{ workload_args.vm_cores | default(1) }}
+    devices:
+      disks:
+        - name: registrydisk
+        - name: cloudinitdisk
+{% if workload_args.storageclass is defined
+    or workload_args.hostpath is defined %}
+        - name: data-volume
+          serial: data
+{% endif %}
+    resources:
+      requests:
+        memory: {{ workload_args.vm_memory | default('5G') }}
+  volumes:
+    - name: registrydisk
+      containerDisk:
+        image: {{ workload_args.vm_image | default('kubevirt/fedora-cloud-container-disk-demo:latest') }}
+    - name: cloudinitdisk
+      cloudInitNoCloud:
+        userData: |-
+          #cloud-config
+          password: fedora
+          chpasswd: { expire: False }
+          bootcmd:
+{% if workload_args.storageclass is defined
+    or workload_args.hostpath is defined %}
+            - "mkdir -p {{ fio_path }} || true"
+            - mkfs.ext4 /dev/disk/by-id/ata-QEMU_HARDDISK_data
+            - "mount /dev/disk/by-id/ata-QEMU_HARDDISK_data {{ fio_path }}"
+{% endif %}
+          runcmd:
+{% if workload_args.vm_image is undefined %}
+            - dnf install -y fio wget curl python3 python3-pip
+{% endif %}
+            - cd /tmp
+{% if workload_args.metadata is defined
+    and (workload_args.metadata.collection|default(false))
+    and (workload_args.metadata.targeted|default(true)) %}
+            - export ES_SERVER={{ elasticsearch.server }}
+            - export ES_PORT={{ elasticsearch.port }}
+{% if workload_args.vm_image is undefined %}
+            - wget https://raw.githubusercontent.com/cloud-bulldozer/bohica/master/stockpile-wrapper/stockpile-wrapper.py
+            - pip3 install elasticsearch-dsl openshift kubernetes redis
+{% endif %}
+            # TODO: start stockpile-wrapper script
+            python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
+{% endif %}
+            - fio --server
+{% if workload_args.storageclass is defined %}
+    - name: data-volume
+      persistentVolumeClaim:
+        claimName: claim-{{ item }}-{{ trunc_uuid }}
+{% elif workload_args.hostpath is defined %}
+    - name: data-volume
+      hostDisk:
+        path: {{ workload_args.hostpath }}
+        capacity: {{ workload_args.storagesize | default("5Gi") }}
+        type: DiskOrCreate
+{% endif %}


### PR DESCRIPTION
Adds kubevirt option to fio-distributed workload.
This spawns kubevirt VMs where the fio server is run in.

Please first merge https://github.com/cloud-bulldozer/ripsaw/pull/353 before merging this
  --> I will rebase after this is done

@bengland2 @jeniferh 