### PR TITLE
Remove redundant greps from CI tests

### DIFF
--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -30,9 +30,6 @@ function functional_test_fio {
   fio_pod=$(get_pod "app=fiod-client-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$fio_pod -n my-ripsaw --timeout=500s" "500s" $fio_pod
   wait_for "kubectl wait --for=condition=complete -l app=fiod-client-$uuid jobs -n my-ripsaw --timeout=500s" "500s" $fio_pod
-  # ensuring the run has actually happened
-  kubectl logs "$fio_pod" -n my-ripsaw
-  kubectl logs "$fio_pod" -n my-ripsaw | grep "fio has successfully finished sample"
 
   index="ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result"
   if check_es "${long_uuid}" "${index}"

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -40,9 +40,6 @@ function functional_test_fs_drift {
   echo fsdrift_pod $fs_drift_pod
   wait_for "kubectl wait --for=condition=Initialized pods/$fsdrift_pod -n my-ripsaw --timeout=500s" "500s" $fsdrift_pod
   wait_for "kubectl wait --for=condition=complete -l app=fs-drift-benchmark-$uuid jobs -n my-ripsaw --timeout=100s" "200s" $fsdrift_pod
-  # Print logs and check status
-  kubectl logs "$fsdrift_pod" -n my-ripsaw
-  kubectl logs "$fsdrift_pod" -n my-ripsaw | grep "RUN STATUS"
 
   indexes="ripsaw-fs-drift-results ripsaw-fs-drift-rsptimes ripsaw-fs-drift-rates-over-time"
   if check_es "${long_uuid}" "${indexes}"

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -30,7 +30,6 @@ function functional_test_hammerdb {
   hammerdb_workload_pod=$(get_pod "app=hammerdb_workload-$uuid" 300)
   kubectl wait --for=condition=Initialized "pods/$hammerdb_workload_pod" --namespace my-ripsaw --timeout=400s
   kubectl wait --for=condition=complete -l app=hammerdb_workload-$uuid --namespace my-ripsaw jobs --timeout=500s
-  kubectl logs "$hammerdb_workload_pod" --namespace my-ripsaw | grep "Timestamp"
 
   index="ripsaw-hammerdb-results"
   if check_es "${long_uuid}" "${index}"

--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -85,7 +85,6 @@ EOF
   wait_for "kubectl wait --for=condition=Initialized pods/$pgbench_pod -n my-ripsaw --timeout=360s" "360s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Ready pods/$pgbench_pod -n my-ripsaw --timeout=60s" "60s" $pgbench_pod
   wait_for "kubectl wait --for=condition=Complete jobs -l app=pgbench-client-$uuid -n my-ripsaw --timeout=300s" "300s" $pgbench_pod
-  kubectl logs -n my-ripsaw $pgbench_pod | grep 'tps ='
 
   index="ripsaw-pgbench-summary ripsaw-pgbench-raw"
   if check_es "${long_uuid}" "${index}"

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -40,10 +40,6 @@ function functional_test_smallfile {
   echo "smallfile_pod ${smallfile_pod}"
   wait_for "kubectl wait --for=condition=Initialized -l app=smallfile-benchmark-$uuid pods --namespace my-ripsaw --timeout=500s" "500s"
   wait_for "kubectl wait --for=condition=complete -l app=smallfile-benchmark-$uuid jobs --namespace my-ripsaw --timeout=100s" "100s"
-  # ensuring the run has actually happened
-  for pod in ${smallfile_pod}; do
-    kubectl logs ${pod} --namespace my-ripsaw | grep "RUN STATUS"
-  done
 
   index="ripsaw-smallfile-results ripsaw-smallfile-rsptimes"
   if check_es "${long_uuid}" "${index}"

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -31,9 +31,6 @@ function functional_test_uperf {
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 900)
   wait_for "kubectl wait -n my-ripsaw --for=condition=Initialized pods/$uperf_client_pod --timeout=500s" "500s" $uperf_client_pod
   wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=500s" "500s" $uperf_client_pod
-  # ensuring that uperf actually ran and we can access metrics
-  kubectl logs "$uperf_client_pod" -n my-ripsaw
-  kubectl logs "$uperf_client_pod" -n my-ripsaw | grep Success
 
   index="ripsaw-uperf-results"
   if check_es "${long_uuid}" "${index}"

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -76,7 +76,6 @@ EOF
   ycsb_load_pod=$(get_pod "name=ycsb-load-$uuid" 300)
   wait_for "kubectl wait --for=condition=Initialized pods/$ycsb_load_pod -n my-ripsaw --timeout=500s" "500s" $ycsb_load_pod
   wait_for "kubectl wait --for=condition=Complete jobs -l name=ycsb-load-$uuid -n my-ripsaw --timeout=300s" "300s" $ycsb_load_pod
-  kubectl logs -n my-ripsaw $ycsb_load_pod | grep 'Starting test'
 
   index="ripsaw-ycsb-summary ripsaw-ycsb-results"
   if check_es "${long_uuid}" "${index}"


### PR DESCRIPTION
These grep statements were to previously ensure the tests completed. Since we now check ES to verify data was uploaded these greps are redundant and more prone to cause failure so we are removing them.