### PR TITLE
Add vegeta benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ a performance baseline of Kubernetes cluster on your provider.
 | [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported         |
 | [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported         |
 | [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported         |
-| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                  | Not Supported         |
+| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported         |
 | [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported         |
+| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported         |
 
 
 ### Reconciliation

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -138,3 +138,7 @@ The following metrics are indexed at one second intervals:
 
 Using the Elasticsearch storage described above, we can build dashboards like the below.
 
+![Vegeta dashboard](https://i.imgur.com/YWophlP.png)
+
+The previous dashboard is available at [arsenal](https://github.com/cloud-bulldozer/arsenal/)
+

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -1,0 +1,140 @@
+# Vegeta
+
+[Vegeta](https://github.com/tsenart/vegeta) is a versatile HTTP load testing tool.
+
+## Running Vegeta
+
+Given that you followed instructions to deploy operator,
+you can modify Vegeta's [cr.yaml](../resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml) to make it fit with your requirements.
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: vegeta-benchmark
+  namespace: my-ripsaw
+spec:
+  workload:
+    name: vegeta
+    args:
+      clients: 2
+      image: quay.io/cloud-bulldozer/vegeta:latest
+      hostnetwork: false
+      targets:
+        - name: 100w-ka
+          urls:
+            - GET https://mydomain.com/test.png
+            - GET http://myunsecuredomain.com
+          samples: 2
+          workers: 100
+          duration: 10
+          keepalive: true
+        - name: 20w
+          urls:
+            - GET https://domain.com/api/endpoint
+          workers: 20
+          duration: 10
+```
+
+It accepts the following parameters:
+
+| Parameter    | Description                                                   | Optional | Default                               |
+|--------------|---------------------------------------------------------------|----------|---------------------------------------|
+| clients      | Number of vegeta clients to launch                            | yes      | 1                                     |
+| image        | Overwrites vegeta image                                       | yes      | quay.io/cloud-bulldozer/vegeta:latest |
+| hostnetwork  | Will launch vegeta clients in the same host network namespace | yes      | false                                 |
+| nodeselector | Allow to specify a k8s nodeSelector for the clients           | yes      | -                                     |
+  
+
+The `targets` parameter contains the list of tests the vegeta pods will perform. Each of the test elements may have the following parameters:
+
+| Option    | Description                                                                                           | Optional | Default |
+|-----------|-------------------------------------------------------------------------------------------------------|----------|---------|
+| name      | Test name                                                                                             | no       | -       |
+| urls      | List of URLs. Specified using the [vegeta http format](https://github.com/tsenart/vegeta#http-format) | no       | -       |
+| samples   | Number of iterations to execute                                                                       | yes      | 1       |
+| workers   | Number of vegeta workers                                                                              | yes      | 1       |
+| duration  | Test duration in seconds                                                                              | no       | -       |
+| keepalive | Specifies whether to reuse TCP connections between HTTP requests                                      | yes      | false   |
+
+
+## Vegeta benchmark behaviour
+
+Tests described under the `targets` section are executed in series. In case of running multiple clients, each vegeta pod run their tests in parallel with the others.
+This test synchronization is achieved using the redis message bus running in the benchmark operator pod.
+Vegeta jobs make usage of pod anti-affinity rules to to deploy vegeta clients on different nodes:
+
+```yaml
+    affinity:                      
+      podAntiAffinity:                                                  
+        preferredDuringSchedulingIgnoredDuringExecution:                          
+          - weight: 100                              
+            podAffinityTerm:                                        
+              labelSelector:                                        
+                matchExpressions:                                        
+                - key: app                                 
+                  operator: In                              
+                  values:                                        
+                  - vegeta-benchmark-{{ trunc_uuid }}
+```
+
+
+## Storing results into Elasticsearch
+
+It's possible to index reults in Elasticseach specifing using a configuration like the below.
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: vegeta-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: esinstance.com
+    port: 9200
+    index_name: ripsaw-vegeta
+  workload:
+    name: vegeta
+    args:
+      hostnetwork: false
+      image: quay.io/cloud-bulldozer/vegeta:latest
+      targets:
+        - name: 100w-ka
+          urls:
+            - GET https://mydomain.com/test.png
+            - GET http://myunsecuredomain.com
+          duration: 10
+```
+
+Where:
+
+- `elasticsearch.server` this is the elasticsearch cluster ip you want to send the result data to for long term storage.
+- `elasticsearch.port` port which elasticsearch is listening, typically `9200`.
+- `elasticsearch.index_name` Elasticseach to index the logs in. This parameter is optional, and defaults to *ripsaw-vegeta*.
+
+In addition, the following parameters can be also specified at the `spec` level to improve ES indexing.
+- `test_user` user is a key that points to user triggering ripsaw, useful to search results in ES. Defaults to *ripsaw*.
+- `clustername` an arbitrary name for your system under test (SUT) that can aid indexing.
+
+The following metrics are indexed at one second intervals:
+
+- rps: Rate of sent requests per second..
+- throughput: Rate of successful requests per second.
+- status_codes: Breakdown of the number status codes observed over the interval.
+- requests: Total number of requests executed until that moment.
+- p99_latency: 99th percentile of the request latency observed over the interval in µs.
+- req_latency: Average latency of all requests observed over the interval in µs.
+- bytes_in: Incoming byte metrics over the interval.
+- bytes_out: Outgoing byte metrics over the interval.
+- targets: Targets file used.
+- iteration: Iteration number.
+- workers: Number of workers.
+- hostname: Hostname from the host where the test is launched.
+- keepalive: Whether keepalive is used or not.
+
+
+### Dashboard example
+
+Using the Elasticsearch storage described above, we can build dashboards like the below.
+

--- a/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
@@ -1,0 +1,30 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: vegeta-benchmark
+  namespace: my-ripsaw
+spec:
+# elasticsearch:
+#   server: <es_instance>
+#   port: 9200
+#   index_name: ripsaw-vegeta
+  workload:
+    name: vegeta
+    args:
+      hostnetwork: false
+      image: quay.io/cloud-bulldozer/vegeta:latest
+      clients: 2
+      targets:
+        - name: 100w-ka
+          urls:
+            - GET https://mydomain.com/test.png
+            - GET http://myunsecuredomain.com
+          samples: 2
+          workers: 100
+          duration: 10
+          keepalive: true
+        - name: 20w
+          urls:
+            - GET https://domain.com/api/endpoint
+          workers: 20
+          duration: 10

--- a/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
@@ -14,7 +14,6 @@ spec:
     name: vegeta
     args:
       hostnetwork: false
-      image: quay.io/cloud-bulldozer/vegeta:latest
       clients: 2
       targets:
         - name: 100w-ka

--- a/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
@@ -8,6 +8,8 @@ spec:
 #   server: <es_instance>
 #   port: 9200
 #   index_name: ripsaw-vegeta
+# test_user: username_to_attach_to_metadata
+  clustername: myk8scluster
   workload:
     name: vegeta
     args:

--- a/roles/vegeta/tasks/main.yml
+++ b/roles/vegeta/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+
+- name: Get current state
+  k8s_info:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: '{{ meta.name }}'
+    namespace: '{{ operator_namespace }}'
+  register: resource_state
+
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: Building
+      complete: false
+  when: resource_state.resources[0].status.state is not defined
+
+- name: Get current state - If it has changed
+  k8s_info:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: '{{ meta.name }}'
+    namespace: '{{ operator_namespace }}'
+  register: resource_state
+
+- name: Capture operator information
+  k8s_info:
+    kind: Pod
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - name = benchmark-operator
+  register: bo
+
+- block:
+  - name: Create targets configmap
+    k8s:
+      definition: "{{ lookup('template', 'targets.yml.j2') | from_yaml }}"
+
+  - name: Create vegeta clients
+    k8s:
+      definition: "{{ lookup('template', 'vegeta.yml.j2') | from_yaml }}"
+    loop: "{{ range(0, workload_args.clients|default(1)|int)|list }}"
+
+  - name: Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Running
+
+  when: resource_state.resources[0].status.state == "Building"
+
+- block:
+
+  - name: Waiting for pods to complete....
+    k8s_info:
+      kind: pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = vegeta-benchmark-{{ trunc_uuid }}
+      field_selectors:
+        - status.phase=Succeeded
+    register: client_pods
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Complete
+        complete: true
+    when: workload_args.clients|default(1)|int == client_pods.resources|length
+
+  when: resource_state.resources[0].status.state == "Running"

--- a/roles/vegeta/templates/targets.yml.j2
+++ b/roles/vegeta/templates/targets.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vegeta-targets-{{ trunc_uuid }}
+  namespace: {{ operator_namespace }}
+data:
+{% for target in workload_args.targets %}
+  {{ target.name }}: |
+{% for u in target.urls %}
+    {{ u }}
+{% endfor %}
+{% endfor %}

--- a/roles/vegeta/templates/targets.yml.j2
+++ b/roles/vegeta/templates/targets.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ operator_namespace }}
 data:
 {% for target in workload_args.targets %}
-  {{ target.name }}: |
+  {{ target.name|replace(" ","") }}: |
 {% for u in target.urls %}
     {{ u }}
 {% endfor %}

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -60,8 +60,8 @@ spec:
               done
             done
             sleep 0.1
-            redis-cli -h {{bo.resources[0].status.podIP}} set vegeta-{{ item }}-{{ trunc_uuid }} notready
-            /opt/snafu/run_snafu.py -t vegeta --targets /tmp/vegeta/{{ t.name }} -u ${uuid} -d {{ t.duration }} --user ${test_user} -w {{ t.workers|default(1) }} -s {{ t.samples|default(1) }} {{ "--keepalive" if t.keepalive|default(false) }}
+            redis-cli -h {{ bo.resources[0].status.podIP }} set vegeta-{{ item }}-{{ trunc_uuid }} notready
+            /opt/snafu/run_snafu.py -t vegeta --targets /tmp/vegeta/{{ t.name|replace(" ","") }} -u ${uuid} -d {{ t.duration }} --user ${test_user} -w {{ t.workers|default(1) }} -s {{ t.samples|default(1) }} {{ "--keepalive" if t.keepalive|default(false) }}
 {% endfor %}
         volumeMounts:
           - name: targets-volume
@@ -71,7 +71,6 @@ spec:
           configMap:
             name: vegeta-targets-{{ trunc_uuid }}
       restartPolicy: OnFailure
-{% if workload_args.pin is sameas true %}
-      nodeSelector:
-        kubernetes.io/hostname: '{{ workload_args.pin_client }}'
+{% if workload_args.nodeselector is defined %}
+      nodeSelector: {{ nodeselector|to_json }} 
 {% endif %}

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -1,0 +1,77 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: vegeta-{{ item }}-{{ trunc_uuid }}
+  namespace: {{ operator_namespace }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: vegeta-benchmark-{{ trunc_uuid }}
+    spec:
+{% if workload_args.hostnetwork is sameas true %}
+      hostNetwork : true
+      serviceAccountName: benchmark-operator
+      serviceAccount: benchmark-operator
+{% endif %}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app 
+                  operator: In
+                  values:
+                  - vegeta-benchmark-{{ trunc_uuid }}
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: vegeta
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/vegeta:latest') }}
+        env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default("ripsaw") }}"
+          - name: clustername
+            value: "{{ clustername }}"
+{% if elasticsearch is defined %}
+          - name: es
+            value: "{{ elasticsearch.server }}"
+          - name: es_port
+            value: "{{ elasticsearch.port }}"
+          - name: es_index
+            value: "{{ elasticsearch.index_name | default("ripsaw-vegeta") }}"
+{% endif %}
+        imagePullPolicy: Always
+        workingDir: /tmp
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+{% for t in workload_args.targets %}
+            redis-cli -h {{ bo.resources[0].status.podIP }} set vegeta-{{ item }}-{{ trunc_uuid }} ready
+            ready=0
+            while [[ ${ready} == 0 ]]; do
+              for client in $(seq 0 {{ workload_args.clients-1 }}); do
+                [[ `redis-cli -h {{ bo.resources[0].status.podIP }} get vegeta-${client}-{{ trunc_uuid }}` != "ready" ]] && ready=0 && break
+                ready=1
+              done
+            done
+            sleep 0.1
+            redis-cli -h {{bo.resources[0].status.podIP}} set vegeta-{{ item }}-{{ trunc_uuid }} notready
+            /opt/snafu/run_snafu.py -t vegeta --targets /tmp/vegeta/{{ t.name }} -u ${uuid} -d {{ t.duration }} --user ${test_user} -w {{ t.workers|default(1) }} -s {{ t.samples|default(1) }} {{ "--keepalive" if t.keepalive|default(false) }}
+{% endfor %}
+        volumeMounts:
+          - name: targets-volume
+            mountPath: /tmp/vegeta
+      volumes:
+        - name: targets-volume 
+          configMap:
+            name: vegeta-targets-{{ trunc_uuid }}
+      restartPolicy: OnFailure
+{% if workload_args.pin is sameas true %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ workload_args.pin_client }}'
+{% endif %}

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -74,3 +74,27 @@ spec:
 {% if workload_args.nodeselector is defined %}
       nodeSelector: {{ nodeselector|to_json }} 
 {% endif %}
+{% if metadata is defined and metadata.collection|default(false) is sameas true and metadata.targeted|default(true) is sameas true %}
+      initContainers:
+      - name: backpack-{{ trunc_uuid }}
+        image: {{ metadata_image | default('quay.io/cloud-bulldozer/backpack:latest') }}
+        command: ["/bin/sh", "-c"]
+{% if metadata is defined and metadata.force|default(false) is sameas true %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force"]
+{% else %}
+        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379"]
+{% endif %}
+        imagePullPolicy: Always
+        securityContext:
+          privileged: {{ metadata.privileged | default(false) | bool }}
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      serviceAccountName: {{ metadata.serviceaccount | default('default') }}
+{% endif %}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -24,6 +24,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'roles/backpack') ]]; then echo "test_backpack.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/hammerdb') ]]; then echo "test_hammerdb.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/smallfile') ]]; then echo "test_smallfile.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'roles/vegeta') ]]; then echo "test_vegeta.sh" >> tests/iterate_tests; fi
 
     # Check for changes in cr files
     if [[ $(echo ${item} | grep 'valid_backpack*') ]]; then echo "test_backpack.sh" >> tests/iterate_tests; fi
@@ -37,6 +38,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'valid_sysbench*') ]]; then echo "test_sysbench.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_uperf*') ]]; then echo "test_uperf.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_ycsb*') ]]; then echo "test_ycsb.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'valid_vegeta*') ]]; then echo "test_vegeta.sh" >> tests/iterate_tests; fi
 
     # Check for changes in test scripts
     test_check=`echo $item | awk -F / '{print $2}'`
@@ -279,12 +281,12 @@ function wait_for_backpack() {
 function check_es() {
   if [[ ${#} != 2 ]]; then
     echo "Wrong number of arguments: ${#}"
-    exit $NOTOK
+    return 1
   fi
-  uuid=$1
-  index=${@:2}
+  local uuid=$1
+  local index=${@:2}
   for my_index in $index; do
     python3 tests/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index \
-      || exit $NOTOK
+      || return 1
   done
 }

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -6,13 +6,14 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: marquez.perf.lab.eng.rdu2.redhat.com
-    port: 9200
+    server: ES_SERVER
+    port: ES_PORT
     index_name: ripsaw-vegeta
+  metadata:
+    collection: true
   workload:
     name: vegeta
     args:
-      image: quay.io/cloud-bulldozer/vegeta:latest
       clients: 2
       targets:
         - name: 2w-ka

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: vegeta-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: marquez.perf.lab.eng.rdu2.redhat.com
+    port: 9200
+    index_name: ripsaw-vegeta
+  workload:
+    name: vegeta
+    args:
+      image: quay.io/cloud-bulldozer/vegeta:latest
+      clients: 2
+      targets:
+        - name: 2w-ka
+          urls:
+            - GET https://1.1.1.1
+            - GET http://1.1.1.1
+          samples: 1
+          workers: 2
+          duration: 5
+          keepalive: true
+        - name: 2w-noka
+          urls:
+            - GET https://1.1.1.1
+          workers: 2
+          duration: 5

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: vegeta-benchmark-hostnetwork
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: marquez.perf.lab.eng.rdu2.redhat.com
+    port: 9200
+    index_name: ripsaw-vegeta
+  workload:
+    name: vegeta
+    args:
+      image: quay.io/cloud-bulldozer/vegeta:latest
+      hostnetwork: true
+      clients: 2
+      targets:
+        - name: 2w-ka
+          urls:
+            - GET https://1.1.1.1
+          samples: 1
+          workers: 2
+          duration: 5
+          keepalive: true

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -6,13 +6,15 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: marquez.perf.lab.eng.rdu2.redhat.com
-    port: 9200
+    server: ES_SERVER
+    port: ES_PORT
     index_name: ripsaw-vegeta
+  metadata:
+    collection: true
+    serviceaccount: benchmark-operator
   workload:
     name: vegeta
     args:
-      image: quay.io/cloud-bulldozer/vegeta:latest
       hostnetwork: true
       clients: 2
       targets:

--- a/tests/test_list
+++ b/tests/test_list
@@ -9,3 +9,4 @@ test_sysbench.sh
 test_uperf.sh
 test_byowl.sh
 test_hammerdb.sh
+test_vegeta.sh

--- a/tests/test_vegeta.sh
+++ b/tests/test_vegeta.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+source tests/common.sh
+
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  [[ $check_logs == 1 ]] && kubectl logs -l app=vegeta-benchmark-$uuid -n my-ripsaw
+  echo "Cleaning up vegeta"
+  wait_clean
+}
+
+
+trap error ERR
+trap finish EXIT
+
+function functional_test_vegeta {
+  check_logs=0
+  wait_clean
+  apply_operator
+  test_name=$1
+  cr=$2
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
+  pod_count "app=vegeta-benchmark-$uuid" 2 900
+  wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=vegeta-benchmark-$uuid jobs --timeout=500s" "500s"
+  check_logs=1
+
+  index="ripsaw-vegeta-results"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+  fi
+}
+
+figlet $(basename $0)
+functional_test_vegeta "Vegeta benchmark" tests/test_crs/valid_vegeta.yaml
+functional_test_vegeta "Vegeta benchmark hostnetwork" tests/test_crs/valid_vegeta_hostnetwork.yaml

--- a/tests/test_vegeta.sh
+++ b/tests/test_vegeta.sh
@@ -39,6 +39,7 @@ function functional_test_vegeta {
     echo "${test_name} test: Success"
   else
     echo "Failed to find data for ${test_name} in ES"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Adding vegeta benchmark. It accepts CRDs like the following:

```yaml 
apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
kind: Benchmark
metadata:
  name: vegeta-benchmark
  namespace: my-ripsaw
spec:
  elasticsearch:              <-- Optional
    server: <es_instance>
    port: 9200
    index_name: ripsaw-vegeta
  workload:
    name: vegeta
    args:
      hostnetwork: true                     <-- Optional. Defaults to false
      image: quay.io/rsevilla/vegeta:latest           <-- Optional. Defaults to quay.io/cloud-bulldozer/vegeta:latest
      clients: 2  <-- Optional. Defaults to 1
      targets:
        - name: 100w-ka
          urls:
            - GET https://mydomain.com/test.png
            - GET http://myunsecuredomain.com
          samples: 2   <-- Optional. Defaults to 1
          workers: 100              <- Optonal. Defaults to 1
          duration: 10
          keepalive: true           <-- Optional. Defaults to false
        - name: 20w
          urls:
            - GET https://domain.com/api/endpoint
          samples: 1
          workers: 20
          duration: 10
          keepalive: false
```

With the above Benchmark object. Ripsaw will kick off two vegeta jobs that will run in parallel ( redis is used to synchronize the processes). These pods use anti-affinity rules to be preferably deployed on different nodes.

The targets list allows to trigger multiple serial tests using different urls and options. Specified URLs accept the syntax described at the Vegeta documentation (https://github.com/tsenart/vegeta#simple-targets).

It doesn't include metadata collection, I think It's not necessary here since the pods deployed are just clients and don't perform any workload. @dry923 @jtaleric  thoughts?

