### PR TITLE
Fix broken URLs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,8 +5,8 @@ COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
-RUN rpm --nodeps -i http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-repos-8.1-1.1911.0.9.el8.x86_64.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.1-1.1911.0.7.el8.noarch.rpm
-RUN dnf install -y --nodocs redis && dnf clean all
+COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
+RUN dnf install -y --nodocs redis --enablerepo=centos8-appstream && dnf clean all
 
 COPY group_vars/ ${HOME}/group_vars/
 COPY roles/ ${HOME}/roles/

--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,0 +1,5 @@
+[centos8-appstream]
+name=CentOS-8-Appstream
+baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+enabled=0
+gpgcheck=0


### PR DESCRIPTION
Fixes broken RPM urls like:
STEP 5: RUN rpm --nodeps -i http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-repos-8.1-1.1911.0.9.el8.x86_64.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.1-1.1911.0.7.el8.noarch.rpm
curl: (22) The requested URL returned error: 404 Not Found