### PR TITLE
Select only one pod in uperf service

### DIFF
--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -5,11 +5,11 @@ metadata:
   name: uperf-service-{{ item }}-{{ trunc_uuid }}
   namespace: '{{ operator_namespace }}'
   labels:
-    app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
+    app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
     type: uperf-bench-server-{{ trunc_uuid }}
 spec:
   selector:
-    type: uperf-bench-server-{{ trunc_uuid }}
+    app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
   ports:
   - name: uperf
     port: 20000


### PR DESCRIPTION
Uperf pod to service workload doesn't work as expected due to how uperf works itself.
When an uperf server initializes a benchmark, it allocates a series of ephemeral ports that are be used for running the workload.

The issue arises when running more than one replica these of uperf slave pods behind a load balancer (a k8s service in this case), since the ephemeral port(s) are allocated only in one of the pods (The pod who received the handshake over the control port 20000), this means that subsequent transactions can fail since they could be steered to a different pod which is not listening in expected the ephemeral port.

That would explain error traces like the below:

```console
# oc logs -f uperf-client-172.30.161.246-c852fabc-6gk48 | grep refused
** TCP: Cannot connect to 172.30.161.246:20003 Connection refused
** TCP: Cannot connect to 172.30.161.246:20003 Connection refused
```

Besides of the above, in case the workload managed to run successfully, this workload won't be load balanced, meaning that all the traffic from the client pod will go to the same server pod since uperf rr and stream workloads perform all their transactions over the same TCP/UDP socket. Therefore results shouldn't be better than standard pod to pod benchmarks.

All of these issues leads to the fix of configuring an unique pod per service, with this workaround, so the test will be executed w/o load balancing (though is not currently working as I mentioned earlier) but always will succeed. 

In order to perform networking stress tests through load balanced pods I think we should look for another benchmarking tool.
