### PR TITLE
Add further PVC options to the fio workload

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -185,6 +185,9 @@ The workload loops are nested as such from the CR options:
 - **filesize**: The size of the file used for each job in the workload (per `numjobs * servers` as described above)
 - **log_sample_rate**: Applied to fio options `log_avg_msec` and `log_hist_msec` in the jobfile configmap; see `fio(1)`
 - **storageclass**: (optional) The K8S StorageClass to use for persistent volume claims (PVC) per server pod
+- **pvcaccessmode**: (optional) The AccessMode to request with the persistent volume claim (PVC) for the fio server. Can be one of ReadWriteOnce,ReadOnlyMany,ReadWriteMany Default: ReadWriteOnce
+- **pvcvolumemode**: (optional) The volmeMode to request with the persistent volume claim (PVC) for the fio server. Can be one of Filesystem,Block Default: Filesystem
+  > Note: It is recommended to change this to `Block` for VM tests
 - **storagesize**: (optional) The size of the PVCs to request from the StorageClass ([note units quirk per above](#understanding-the-cr-options))
 - **rook_ceph_drop_caches**: (optional) If set to `True`, the Rook-Ceph OSD caches will be dropped prior to each sample
 - **rook_ceph_drop_cache_pod_ip**: (optional) The IP address of the pod hosting the Rook-Ceph cache drop URL -- See [cache drop pod instructions](#dropping-rook-ceph-osd-caches) below

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
@@ -60,6 +60,10 @@ spec:
       # interval between i/o stat samples in milliseconds
       log_sample_rate: 3000
       storageclass: ocs-storagecluster-ceph-rbd
+      # Can be one of ReadWriteOnce,ReadOnlyMany,ReadWriteMany Default: ReadWriteOnce
+      pvcaccessmode: ReadWriteMany
+      # Can be one of Filesystem,Block Default: Filesystem
+      pvcvolumemode: Block
       storagesize: 5Gi
       #rook_ceph_drop_caches: True
       #rook_ceph_drop_cache_pod_ip: 192.168.111.20

--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -51,11 +51,12 @@
           annotations:
              volume.beta.kubernetes.io/storage-class: "{{ workload_args.storageclass }}"
         spec:
-           accessModes:
-             - ReadWriteOnce
-           resources:
-             requests:
-               storage: "{{ workload_args.storagesize }}"
+          accessModes:
+            - "{{ workload_args.pvcaccessmode | default('ReadWriteOnce') }}"
+          volumeMode: "{{ workload_args.pvcvolumemode | default('Filesystem') }}"
+          resources:
+            requests:
+              storage: "{{ workload_args.storagesize }}"
     with_sequence: start=1 count={{ workload_args.servers|default('1')|int }}
     when: workload_args.storageclass is defined
 


### PR DESCRIPTION
This enables us to define the accessMode and volumeMode of the PVC
We want this for VM workloads to schedule RWX Block PVCs

Ping @rsevilla87 @jeniferh 