### PR TITLE
Updating CI test script to create unique crd names for each run

### DIFF
--- a/tests/test_pgbench.sh
+++ b/tests/test_pgbench.sh
@@ -10,10 +10,7 @@ function finish {
   fi
 
   echo "Cleaning up pgbench"
-  kubectl delete -n my-ripsaw benchmark/pgbench-benchmark
-  kubectl delete -n my-ripsaw deployment/postgres
-  kubectl delete -n my-ripsaw configmap/postgres-config
-  delete_operator
+  wait_clean
 }
 
 trap error ERR

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -10,10 +10,7 @@ function finish {
   fi
 
   echo "Cleaning up ycsb"
-  kubectl delete -n my-ripsaw benchmark/ycsb-mongo-benchmark
-  kubectl delete -n my-ripsaw statefulset/mongo
-  kubectl delete -n my-ripsaw service/mongo
-  delete_operator
+  wait_clean
 }
 
 trap error ERR


### PR DESCRIPTION
With the new CI environment there is the chance that different runs will delete the crd while its in use by another. This change adjusts the crd name to be unique for each run.