### PR TITLE
fixing a naming issue

### DIFF
--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -14,7 +14,7 @@ spec:
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
       ttlSecondsAfterFinished: 600
-{% if workload_args.nodeselector is defined %}
+{% if workload_args.node_selector is defined %}
       nodeSelector:
         '{{ workload_args.node_selector.split("=")[0] }}': '{{ workload_args.node_selector.split("=")[1] }}'
 {% endif %}

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -15,7 +15,7 @@ spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
-{% if workload_args.nodeselector is defined %}
+{% if workload_args.node_selector is defined %}
       nodeSelector:
         '{{ workload_args.node_selector.split("=")[0] }}': '{{ workload_args.node_selector.split("=")[1] }}'
 {% endif %}


### PR DESCRIPTION
### Description
It has to be either nodeselector or node_selector everywhere. Fixed that

### Fixes
node_selector in the job template files was not used everywhere. 