### PR TITLE
Adds ability to use different kubernetes configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ ifdef BATS_TESTS
   FILTERED_TESTS := -f "$(BATS_TESTS)"
 endif
 
+KUBECONFIG ?= ~/.kube/config
+
 all: image-build
 
 ##@ General
@@ -107,17 +109,17 @@ manifest-build:
 ##@ Deployment
 
 install: kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl --kubeconfig $(KUBECONFIG) apply -f -
 
 uninstall: kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | kubectl --kubeconfig $(KUBECONFIG) delete -f -
 
 deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl --kubeconfig $(KUBECONFIG) apply -f -
 
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | kubectl --kubeconfig $(KUBECONFIG) delete -f -
 
 
 .PHONY: kustomize

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ make image-build image-push deploy IMG=$YOUR_IMAGE
 
 > Note: building the image requires podman
 
+You can choose which cluster to use setting the variable KUBECONFIG
+
+```bash
+KUBECONFIG=~/configs/your.config make deploy
+```
+
 ## Installation (Helm)
 
 Installing the benchmark-operator via Helm can be done with the following commands. This requires


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

Adds ability to use different kubernetes configs

By setting the KUBECONFIG variable you can target different clusters, without having to change contexts on your main kubeconfig.

### Fixes
