### PR TITLE
Enable multiple client/server pairs with NodePort uperf

### DIFF
--- a/e2e/uperf/uperf_serviceip_nodeport.yaml
+++ b/e2e/uperf/uperf_serviceip_nodeport.yaml
@@ -25,7 +25,7 @@ spec:
       multus:
         enabled: false
       samples: 1
-      pair: 1
+      pair: 2
       test_types:
         - stream
       protos:

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -9,9 +9,14 @@
       - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
   register: server_pods
 
+- name: set pod_sequence
+  set_fact:
+    pod_sequence: "{{ pod_hi_idx|int }}"
+
 - name: Generate uperf xml files
   k8s:
     definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
+  with_sequence: start=0 end={{ pod_sequence|int }}
 
 - block:
   ### <POD> kind 
@@ -21,8 +26,16 @@
     vars: 
       resource_item: "{{ server_pods.resources }}"
     when: 
-      - ( workload_args.serviceip|default(False) == False and server_pods.resources|length > 0 ) or 
-        ( workload_args.serviceip|default(False) == True and server_pods.resources|length > 0 and 
+      - ( workload_args.serviceip|default(False) == False and server_pods.resources|length > 0 )
+
+
+  - name: Start Client(s) with nodeport serviceIP
+    k8s:
+      definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+    vars:
+      resource_item: "{{ server_pods.resources }}"
+    when:
+      - ( workload_args.serviceip|default(False) == True and server_pods.resources|length > 0 and 
           workload_args.servicetype | default("clusterip") == "nodeport" )
 
    #

--- a/roles/uperf/templates/configmap.yml.j2
+++ b/roles/uperf/templates/configmap.yml.j2
@@ -1,8 +1,9 @@
 ---
+{% set control_port = 30000 %}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: uperf-test-{{ trunc_uuid }}
+  name: uperf-test-{{ item }}-{{ trunc_uuid }}
   namespace: '{{ operator_namespace }}'
 data:
 {% for test in workload_args.test_types %}
@@ -22,7 +23,7 @@ data:
     {% if ( 'rr' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="size={{wsize}}"/>
@@ -35,7 +36,7 @@ data:
     {% if ( 'stream' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="count=16 size={{wsize}}"/>
@@ -48,7 +49,7 @@ data:
     {% if ( 'maerts' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=read options="count=16 size={{rsize}}"/>

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -1,4 +1,5 @@
 ---
+{% set control_port = 30000 %}
 apiVersion: v1
 kind: List
 metadata: {}
@@ -60,7 +61,7 @@ items:
 {% endif %}
             imagePullPolicy: Always
             command: ["/bin/sh","-c"]
-            args: ["uperf -s -v -P 30000"]
+            args: ["uperf -s -v -P {{ control_port|int + item|int * 100 }}"]
           restartPolicy: OnFailure
 {% if workload_args.pin is sameas true %}
           nodeSelector:
@@ -73,7 +74,7 @@ items:
           securityContext:
             sysctls:
             - name: net.ipv4.ip_local_port_range
-              value: 30000 30011
+              value: 30000 32011
 {% endif %}
 {% filter indent(width=4, first=True) %}
 {% include "metadata.yml.j2" %}

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -1,4 +1,5 @@
 ---
+{% set control_port = 30000 %}
 apiVersion: v1
 kind: List
 metadata: {}
@@ -32,20 +33,20 @@ items:
       type: NodePort
       ports:
       - name: uperf
-        port: 30000
-        targetPort: 30000
-        nodePort: 30000
+        port: {{ control_port|int + item|int * 100 }}
+        targetPort: {{ control_port|int + item|int * 100 }}
+        nodePort: {{ control_port|int + item * 100 }} 
         protocol: TCP
-{% for num in range(30001,30012,1) %}
-      - name: uperf-control-tcp-{{num}}
-        port: {{num}}
-        targetPort: {{num}}
-        nodePort: {{num}}
+{% for num in range(1,12,1) %}
+      - name: uperf-control-tcp-{{ control_port|int + item * 100 + num }}
+        port: {{ control_port|int + item * 100 + num }}
+        targetPort: {{ control_port|int + item * 100 + num }}
+        nodePort: {{ control_port|int + item * 100 + num }}
         protocol: TCP
-      - name: uperf-control-udp-{{num}}
-        port: {{num}}
-        targetPort: {{num}}
-        nodePort: {{num}}
+      - name: uperf-control-udp-{{ control_port|int + item * 100 + num }}
+        port: {{ control_port|int + item * 100 + num }}
+        targetPort: {{ control_port|int + item * 100 + num }}
+        nodePort: {{ control_port|int + item * 100 + num }}
         protocol: UDP
 {% endfor %}
 {% else %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -1,4 +1,5 @@
 ---
+{% set control_port = 30000 %}
 apiVersion: v1
 kind: List
 metadata: {}
@@ -9,7 +10,7 @@ items:
     metadata:
 {% if workload_args.serviceip is sameas true %}
 {% if workload_args.servicetype | default("clusterip") == "nodeport" %}
-      name: 'uperf-client-{{item.status.hostIP}}-{{ trunc_uuid }}'
+      name: 'uperf-client-{{item.status.hostIP}}-{{ loop.index - 1 }}-{{ trunc_uuid }}'
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
       name: 'uperf-client-{{item.status.loadBalancer.ingress[0].ip}}-{{ trunc_uuid }}'
 {% else %}
@@ -124,6 +125,7 @@ items:
               - "export h={{item.status.podIP}};
 {% endif %}
 {% endif %}
+                 export port={{ control_port + (loop.index - 1) * 100 }}
 {% if (workload_args.colocate is defined) %}
                  export colocate={{ workload_args.colocate}};
 {% endif %}
@@ -217,7 +219,7 @@ items:
           volumes:
             - name: config-volume
               configMap:
-                name: uperf-test-{{ trunc_uuid }}
+                name: uperf-test-{{ loop.index - 1 }}-{{ trunc_uuid }}
           restartPolicy: Never
 {% if workload_args.pin is sameas false %}
 {% if workload_args.colocate is sameas true %}

--- a/tests/test_crs/valid_uperf_serviceip_nodeport.yaml
+++ b/tests/test_crs/valid_uperf_serviceip_nodeport.yaml
@@ -28,7 +28,7 @@ spec:
       multus:
         enabled: false
       samples: 2
-      pair: 1
+      pair: 2
       test_types:
         - stream
         - rr
@@ -40,6 +40,5 @@ spec:
         - 512
       nthrs:
         - 1
-        - 2
       runtime: 2
       debug: true


### PR DESCRIPTION
Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description
Currently uperf with NodePort servicetype only works
with `pairs: 1`. This PR fixes the issue with running multiple
pairs.

### Fixes
#757


Thanks to Murali for the initial feedback and testing the PR to find issues.
