### PR TITLE
Add storageClassName to fs-drift PVC

### DIFF
--- a/roles/fs-drift/tasks/main.yml
+++ b/roles/fs-drift/tasks/main.yml
@@ -22,6 +22,7 @@
         spec:
           accessModes:
             - "{{ workload_args.access_mode }}"
+          storageClassName: "{{ workload_args.storageclass }}"
           resources:
             requests:
               storage: "{{workload_args.storagesize}}"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `volume.beta.kubernetes.io/storage-class` [annotation for storageClasses is deprecated](volume.beta.kubernetes.io/storage-class: "{{workload_args.storageclass}}") and `spec.storageClassName` should be used.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
