### PR TITLE
kustomize v5.2.1 linux s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ ifeq (,$(shell which kustomize 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(KUSTOMIZE)) ;\
-	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_$(OS)_$(ARCH).tar.gz | \
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.2.1/kustomize_v5.2.1_$(OS)_$(ARCH).tar.gz | \
 	tar xzf - -C bin/ ;\
 	}
 else


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->
Dear Bulldozer Team!

Running the operator in the Openshift at IBM Z (s390x arch) the kustomize binary not found.
Here proposed to use a more recent version of the binary.

This is the recent version which has the s390x as well as the other archs:
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.2.1

This is the current kustomize version where only the intel arch binary is present:
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.5.4

Have a nice day!


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.